### PR TITLE
Fix printf in tester usage

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -502,7 +502,11 @@ void print_main_usage(const char *program_name)
            "\t%s routine [-h|--help]\n"
            "\t%s routine [parameter1, parameter2, ...]\n"
            "\n"
-           "Available routines:", program_name, program_name, program_name);
+           "Available routines:",
+           program_name,
+           program_name,
+           program_name,
+           program_name);
     for (int i = 0; routines[i].name != NULL; ++i) {
         if (i % 4 == 0) {
             printf("\n\t");


### PR DESCRIPTION
The printf statement has four `%s`, but only provides `program_name` three times.