### PR TITLE
Gbmm flops calc fix

### DIFF
--- a/compute/zgbmm.c
+++ b/compute/zgbmm.c
@@ -65,7 +65,8 @@
  *          The width of the band below the diagonal in band matrix A.
  *
  * @param[in] ku
- *          The width of the band above the diagonal in band matrix A.
+ *          The width of the band [above/to the right of] the diagonal
+ *          in band matrix A.
  *
  * @param[in] alpha
  *          The scalar alpha.
@@ -149,12 +150,12 @@ int plasma_zgbmm(plasma_enum_t transa, plasma_enum_t transb,
         return -5;
     }
     if ((kl < 0) ||
-        (kl > imax(m,n)-1)) {
+        (kl > imax(m,k)-1)) {
         plasma_error("illegal value of kl");
         return -6;
     }
     if ((ku < 0) ||
-        (ku > imax(m,n)-1)) {
+        (ku > imax(m,k)-1)) {
         plasma_error("illegal value of ku");
         return -7;
     }

--- a/compute/zgbmm.c
+++ b/compute/zgbmm.c
@@ -62,11 +62,10 @@
  *          of the matrix op( B ). k >= 0.
  *
  * @param[in] kl
- *          The width of the band below the diagonal in band matrix A.
+ *          the lower bandwidth of band matrix A (bandwidth below diagonal)
  *
  * @param[in] ku
- *          The width of the band [above/to the right of] the diagonal
- *          in band matrix A.
+ *          the upper bandwidth of band matrix A (bandwidth above diagonal)
  *
  * @param[in] alpha
  *          The scalar alpha.
@@ -150,12 +149,12 @@ int plasma_zgbmm(plasma_enum_t transa, plasma_enum_t transb,
         return -5;
     }
     if ((kl < 0) ||
-        (kl > imax(m,k)-1)) {
+        (kl > m-1)) {
         plasma_error("illegal value of kl");
         return -6;
     }
     if ((ku < 0) ||
-        (ku > imax(m,k)-1)) {
+        (ku > k-1)) {
         plasma_error("illegal value of ku");
         return -7;
     }

--- a/compute/zgbset.c
+++ b/compute/zgbset.c
@@ -31,11 +31,21 @@ void plasma_zgbset(int m, int n, int kl, int ku,
     if (m == 0 || n == 0)
         return;
 
+    if ((kl < 0) ||
+        (kl > imax(m,n)-1)) {
+        plasma_error("illegal value of kl");
+        return;
+    }
+    if ((ku < 0) ||
+        (ku > imax(m,n)-1)) {
+        plasma_error("illegal value of ku");
+        return;
+    }
     // square matrix OR rectangular tall matrix
     if(m>=n)
     {
         int cornerI, cornerJ, extralower, extraupper;
-        if(kl+ku <= m)
+        if(kl+ku < m) // can be < or <=, the difference is zlaset on m=0
         {
             plasma_zlaset(PlasmaGeneral, m-kl-ku, n-1, 0, 0, pA+1+kl, lda+1);
             extralower = ku-1;
@@ -49,7 +59,8 @@ void plasma_zgbset(int m, int n, int kl, int ku,
         for(; extralower > 0; extralower--)
         {
             cornerI = m-extralower;
-            plasma_zlaset(PlasmaGeneral,1,extralower,0,0,pA+cornerI,lda+1);
+            plasma_zlaset(PlasmaGeneral,1,(extralower < n ? extralower: n),
+                                          0,0,pA+cornerI,lda+1);
         }
         for(; extraupper > 0; extraupper--)
         {
@@ -57,6 +68,7 @@ void plasma_zgbset(int m, int n, int kl, int ku,
             plasma_zlaset(PlasmaGeneral,1,extraupper,0,0,pA+lda*cornerJ,lda+1);
         }
         if(m>n) // m strictly greater
+                // (clears a "tail" on bottom right below diag)
         {
             plasma_zlaset(PlasmaGeneral, (m-n)-kl, 1, 0, 0,
                             pA+(lda*(n-1))+(n+kl), lda);
@@ -67,7 +79,7 @@ void plasma_zgbset(int m, int n, int kl, int ku,
     {
         // clear out a square part of the matrix (left side).
         int cornerI, cornerJ, extralower, extraupper;
-        if(kl+ku <= m)
+        if(kl+ku < m)
         {
             plasma_zlaset(PlasmaGeneral, m-kl-ku, m-1, 0, 0, pA+1+kl, lda+1);
             extralower = ku-1;
@@ -92,6 +104,10 @@ void plasma_zgbset(int m, int n, int kl, int ku,
         for(int i = 0; i < m; i++)
         {
             int blcols = (i-(m-1)+ku) > 0 ? (i-(m-1)+ku) : 0;
+            if (n-(m+blcols) <= 0)
+            {
+               continue;
+            }
             plasma_zlaset(PlasmaGeneral,1,n-(m+blcols),0,0,
                                           pA+(lda*(m+blcols))+i,lda);
         }

--- a/compute/zgbset.c
+++ b/compute/zgbset.c
@@ -32,12 +32,12 @@ void plasma_zgbset(int m, int n, int kl, int ku,
         return;
 
     if ((kl < 0) ||
-        (kl > imax(m,n)-1)) {
+        (kl > m-1)) {
         plasma_error("illegal value of kl");
         return;
     }
     if ((ku < 0) ||
-        (ku > imax(m,n)-1)) {
+        (ku > n-1)) {
         plasma_error("illegal value of ku");
         return;
     }
@@ -54,7 +54,7 @@ void plasma_zgbset(int m, int n, int kl, int ku,
         else
         {
             extralower = m-1-kl;
-            extraupper = m-1-ku;
+            extraupper = n-1-ku;
         }
         for(; extralower > 0; extralower--)
         {
@@ -67,8 +67,12 @@ void plasma_zgbset(int m, int n, int kl, int ku,
             cornerJ = n-extraupper;
             plasma_zlaset(PlasmaGeneral,1,extraupper,0,0,pA+lda*cornerJ,lda+1);
         }
-        if(m>n) // m strictly greater
-                // (clears a "tail" on bottom right below diag)
+        if(m>n+kl) // m strictly greater
+        // clears a "tail" on bottom right below diagonal
+        // note that for small bandwidths on large rectangular matrices of
+        // this kind will lead the above code to neglect zeroing elements
+        // in the final column of pA, which need to be cleared if 
+        // m > n+kl
         {
             plasma_zlaset(PlasmaGeneral, (m-n)-kl, 1, 0, 0,
                             pA+(lda*(n-1))+(n+kl), lda);
@@ -88,7 +92,7 @@ void plasma_zgbset(int m, int n, int kl, int ku,
         else
         {
             extralower = m-1-kl;
-            extraupper = m-1-ku;
+            extraupper = n-1-ku;
         }
         for(; extralower > 0; extralower--)
         {

--- a/test/flops.h
+++ b/test/flops.h
@@ -105,18 +105,16 @@ static double  flops_sgemm(double m, double n, double k)
 //------------------------------------------------------------ gbmm
 static double fmuls_gbmm(double m, double n, double k, double ku, double kl)
 {
-    // recall A is an m x k matrix, and it the only band matrix
-    double elements = m < k ? m : k;
-    double k_leftover;
+    // recall A is an m x k matrix, and it is the only band matrix
+    double elements, k_leftover;
     // elements from kl
-    elements += ku*m;
-    k_leftover = m+ku-k;
+    elements += (ku+1+kl)*(k<m?k:m);
+    k_leftover = (m-k<0?m-k:0)+ku;
     if(k_leftover > 0)
     {
         elements -= (k_leftover)*(k_leftover+1)/2;
     }
-    elements += kl*k;
-    k_leftover = k+kl-m;
+    k_leftover = (k-m<0?k-m:0)+kl;
     if(k_leftover > 0)
     {
         elements -= (k_leftover)*(k_leftover+1)/2;
@@ -126,18 +124,16 @@ static double fmuls_gbmm(double m, double n, double k, double ku, double kl)
 
 static double fadds_gbmm(double m, double n, double k, double ku, double kl)
 {
-    // recall A is an m x k matrix, and it the only band matrix
-    double elements = m < k ? m : k;
-    double k_leftover;
+    // recall A is an m x k matrix, and it is the only band matrix
+    double elements, k_leftover;
     // elements from kl
-    elements += ku*m;
-    k_leftover = m+ku-k;
+    elements += (ku+1+kl)*(k<m?k:m);
+    k_leftover = (m-k<0?m-k:0)+ku;
     if(k_leftover > 0)
     {
         elements -= (k_leftover)*(k_leftover+1)/2;
     }
-    elements += kl*k;
-    k_leftover = k+kl-m;
+    k_leftover = (k-m<0?k-m:0)+kl;
     if(k_leftover > 0)
     {
         elements -= (k_leftover)*(k_leftover+1)/2;

--- a/test/flops.h
+++ b/test/flops.h
@@ -102,6 +102,61 @@ static double  flops_dgemm(double m, double n, double k)
 static double  flops_sgemm(double m, double n, double k)
     { return    fmuls_gemm(m, n, k) +    fadds_gemm(m, n, k); }
 
+//------------------------------------------------------------ gbmm
+static double fmuls_gbmm(double m, double n, double k, double ku, double kl)
+{
+    // recall A is an m x k matrix, and it the only band matrix
+    double elements = m < k ? m : k;
+    double k_leftover;
+    // elements from kl
+    elements += ku*m;
+    k_leftover = m+ku-k;
+    if(k_leftover > 0)
+    {
+        elements -= (k_leftover)*(k_leftover+1)/2;
+    }
+    elements += kl*k;
+    k_leftover = k+kl-m;
+    if(k_leftover > 0)
+    {
+        elements -= (k_leftover)*(k_leftover+1)/2;
+    }
+    return elements*n;
+}
+
+static double fadds_gbmm(double m, double n, double k, double ku, double kl)
+{
+    // recall A is an m x k matrix, and it the only band matrix
+    double elements = m < k ? m : k;
+    double k_leftover;
+    // elements from kl
+    elements += ku*m;
+    k_leftover = m+ku-k;
+    if(k_leftover > 0)
+    {
+        elements -= (k_leftover)*(k_leftover+1)/2;
+    }
+    elements += kl*k;
+    k_leftover = k+kl-m;
+    if(k_leftover > 0)
+    {
+        elements -= (k_leftover)*(k_leftover+1)/2;
+    }
+    return elements*n;
+}
+
+static double  flops_zgbmm(double m, double n, double k, double ku, double kl)
+    { return 6.*fmuls_gbmm(m, n, k, ku, kl) + 2.*fadds_gbmm(m, n, k, ku, kl); }
+
+static double  flops_cgbmm(double m, double n, double k, double ku, double kl)
+    { return 6.*fmuls_gbmm(m, n, k, ku, kl) + 2.*fadds_gbmm(m, n, k, ku, kl); }
+
+static double  flops_dgbmm(double m, double n, double k, double ku, double kl)
+    { return    fmuls_gbmm(m, n, k, ku, kl) +    fadds_gbmm(m, n, k, ku, kl); }
+
+static double  flops_sgbmm(double m, double n, double k, double ku, double kl)
+    { return    fmuls_gbmm(m, n, k, ku, kl) +    fadds_gbmm(m, n, k, ku, kl); }
+
 //------------------------------------------------------------ symm/hemm
 static double fmuls_symm(plasma_enum_t side, double m, double n)
 {

--- a/test/test_zgbmm.c
+++ b/test/test_zgbmm.c
@@ -176,7 +176,7 @@ void test_zgbmm(param_value_t param[], bool run)
     // and multiplications by zero.
     // int band_k = 1 + ((ku+param[PARAM_NB].i-1)/param[PARAM_NB].i);
                      // ((kl+param[PARAM_NB].i-1)/param[PARAM_NB].i);
-    param[PARAM_GFLOPS].d = flops_zgemm(m, n, ku+kl+1) / time / 1e9;
+    param[PARAM_GFLOPS].d = flops_zgbmm(m, n, k, ku, kl) / time / 1e9;
 
     //================================================================
     // Test results by comparing to a reference implementation.


### PR DESCRIPTION
I noticed that one of the issues I was seeing with high `kl` and `ku` was simply that the calculation for FLOPs was inexact. I have implemented a fix to that alongside two other minor changes.