### PR TITLE
bugfix: elements initialized with +=

### DIFF
--- a/test/flops.h
+++ b/test/flops.h
@@ -136,7 +136,6 @@ static double fadds_gbmm(double m, double n, double k, double ku, double kl)
     {
         elements -= (k_leftover)*(k_leftover+1)/2;
     }
-    if(k_leftover > 0)
     return elements*n;
 }
 

--- a/test/flops.h
+++ b/test/flops.h
@@ -107,8 +107,7 @@ static double fmuls_gbmm(double m, double n, double k, double ku, double kl)
 {
     // recall A is an m x k matrix, and it is the only band matrix
     double elements, k_leftover;
-    // elements from kl
-    elements += (ku+1+kl)*(k<m?k:m);
+    elements = (ku+1+kl)*(k<m?k:m);
     k_leftover = (m-k<0?m-k:0)+ku;
     if(k_leftover > 0)
     {
@@ -126,8 +125,7 @@ static double fadds_gbmm(double m, double n, double k, double ku, double kl)
 {
     // recall A is an m x k matrix, and it is the only band matrix
     double elements, k_leftover;
-    // elements from kl
-    elements += (ku+1+kl)*(k<m?k:m);
+    elements = (ku+1+kl)*(k<m?k:m);
     k_leftover = (m-k<0?m-k:0)+ku;
     if(k_leftover > 0)
     {
@@ -138,6 +136,7 @@ static double fadds_gbmm(double m, double n, double k, double ku, double kl)
     {
         elements -= (k_leftover)*(k_leftover+1)/2;
     }
+    if(k_leftover > 0)
     return elements*n;
 }
 


### PR DESCRIPTION
Piotr,

I noticed in my calculations that `elements` is not initialized: the first time it is used it is assigned to with `+=`. I suspect it was an artifact from removing lines in the editing process. Regardless, this PR will fix that!