### PR TITLE
New STEVX2 Request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,9 @@ compute/spbtrf.c compute/spbtrs.c compute/dlangb.c compute/clangb.c
 compute/slangb.c compute/dposv.c compute/cposv.c compute/sposv.c
 compute/dpoinv.c compute/cpoinv.c compute/spoinv.c compute/dpotri.c
 compute/cpotri.c compute/spotri.c
+compute/slaebz2.c compute/dlaebz2.c 
+compute/slaneg2.c compute/dlaneg2.c 
+compute/sstevx2.c compute/dstevx2.c 
 compute/pslange.c compute/pclaset.c compute/psorglq_tree.c
 compute/psormqr_tree.c compute/pdgelqf_tree.c compute/pslag2d.c
 compute/pcunmqr_tree.c compute/psgeqrf_tree.c compute/pspotrf.c
@@ -377,6 +380,7 @@ test/test_zpoinv.c test/test_dpoinv.c test/test_cpoinv.c test/test_spoinv.c
 test/test_zpotrf.c test/test_dpotrf.c test/test_cpotrf.c test/test_spotrf.c
 test/test_zpotri.c test/test_dpotri.c test/test_cpotri.c test/test_spotri.c
 test/test_zpotrs.c test/test_dpotrs.c test/test_cpotrs.c test/test_spotrs.c
+test/test_dstevx2.c test/test_sstevx2.c
 test/test_zsymm.c test/test_dsymm.c test/test_csymm.c test/test_ssymm.c
 test/test_zsyr2k.c test/test_dsyr2k.c test/test_csyr2k.c test/test_ssyr2k.c
 test/test_zsyrk.c test/test_dsyrk.c test/test_csyrk.c test/test_ssyrk.c

--- a/compute/zlaebz2.c
+++ b/compute/zlaebz2.c
@@ -1,0 +1,365 @@
+/**
+ *
+ * @file 
+ *
+ *  PLASMA is a software package provided by:
+ *  University of Tennessee, US,
+ *  University of Manchester, UK.
+ *
+ * @precisions normal z -> s d 
+ *
+ **/
+
+/*
+ * This file is a z-template to generate s and d code.
+ * Only s and d are compiled; not c or z. 
+ */
+ 
+#include "plasma.h"
+#include "plasma_internal.h"     /* needed for imin, imax. */
+#include "plasma_zlaebz2_work.h" /* work areas. */
+
+#include <string.h>
+#include <omp.h>
+#include <math.h>
+#include <float.h>
+#include "mkl_lapack.h"
+
+/******************************************************************************
+ * This code is not designed to be called directly by users; it is a subroutine
+ * for zstevx2.c. 
+ *
+ * Specifically, this is launched in parallel mode, and all the parameters are
+ * contained in the already initialized and populated zlaebz2_WorkStack_t; For 
+ * example, from zstevx2:
+ *
+ *  #pragma omp parallel proc_bind(close)
+ *  {
+ *     thread_work(&workStack);
+ *  }
+ *
+ * We are given the WorkStack; we only exit when 
+ * workStack->finished == workStack->eigenvalues.  The ToDo chain works like a
+ * stack, we pop Brackets to work on.  Each Bracket is bisected down to one
+ * eigenvalue; right-halves are pushed back on the ToDo stack as future work to
+ * do.
+ *
+ * For range=PlasmaRangeI: We still bisect on range values, but the conditions
+ * change. We begin with the full range Gerschgorin [low, hi+ulp). We compute
+ * nLT_low, nLT_hi, but we need the indices il, iu. So these nLT_x values are
+ * the conditions: The smallest (1 relative) index the bracket can contain is
+ * nLT_low+1. e.g. if nLT_low = 0, then index 1 may be in the bracket.  if
+ * nLT_low=7, then index 8 may be in the bracket.
+ *
+ * The largest (1 relative) index the bracket can contain is nLT_hi: If
+ * nLT_hi=n, then the nth eigenvalue might be in the bracket. So the bracket
+ * contains indices [nLT_low+1, nLT_hi]. How does that intersect [il, iu]?
+ *
+ * Low end: If iu < nLT_low+1, then [il,iu] is out of Bracket.  Hi end: If il >
+ * nLT_hi, then [il,iu] is out of Bracket.  Otherwise there is overlap. We find
+ * the midpoint, and compute nLT_midp.
+ *
+ * If nLT_midp were the new high (for the left bracket), then if il > nLT_midp,
+ * we can discard the left bracket. 
+ *
+ * If nLT_midp were the new low (for the right bracket), then if iu <
+ * nLT_midp+1, we can discard the right bracket. 
+ *
+ * The number of eigenvalues in the bracket is still (nLT_hi - nLT_low). if
+ * that is ever zero, we can discard the bracket.
+ *
+ * Stage: Init: establish nLT_low, nLT_hi, numEV in the bracket.
+ *
+ * Stage: Bisection. We use Bisection to divide the range until lowerBound and
+ * upperBound cannot be averaged. (The result is one or the other).  If we
+ * subdivide and the two halves both have eigenvalues, we create a new bracket
+ * and (Critical) add it to the ToDo stack, with Bisection as the workstage.
+ *
+ * Once a range can't be subdivided (the UpperBound=LowerBound+ULP); we store
+ * the lowerBound as the eigenvalue and numEV as the multiplicity in the
+ * caller's array (pVal, pMul), and enter the next Stage, GetVector.
+ *
+ * Stage: GetVector. At this point we know the index of the eigenpair within
+ * the user's arrays. If PlasmaVec, we find the eigenvector using the LAPACK
+ * routine zstein, storing it in its proper place in pVec.  Then we add numEV
+ * to the count of finished eigenpairs, and free the bracket.
+ *
+ * The most comparable serial LAPACK routine is DSTEVX.
+ *
+ * Once all thread work is complete, the code will condense these arrays to
+ * just the actual number of unique eigenvalues found.
+ *
+ * This routine is most similar to a portion of LAPACK DLAEBZ.
+ *****************************************************************************/
+
+/*******************************************************************************
+ * Use LAPACK zstein to find a single eigenvector.  We may use this routine
+ * hundreds or thousands of times, so instead of allocating/freeing the work
+ * spaces repeatedly, we have an array of pointers, per thread, to workspaces
+ * we allocate if not already allocated for this thread. So we don't allocate
+ * more than once per thread. These are freed by the main program before exit.
+ * Returns INFO. 0=success. <0, |INFO| is invalid argument index. >0, if
+ * eigenvector failed to converge.
+*******************************************************************************/
+
+static int useStein( plasma_complex64_t *diag, plasma_complex64_t *offd, 
+                     plasma_complex64_t u,     plasma_complex64_t *v, 
+                     int N, zlaebz2_Stein_Array_t *myArrays) {
+    int M=1, LDZ=N, INFO;
+    int thread = omp_get_thread_num();
+
+    if (myArrays[thread].IBLOCK == NULL) {
+        myArrays[thread].IBLOCK = (int*) calloc(N, sizeof(int));
+        if (myArrays[thread].IBLOCK != NULL) myArrays[thread].IBLOCK[0]=1;
+    }
+
+    if (myArrays[thread].ISPLIT == NULL) {
+        myArrays[thread].ISPLIT = (int*) calloc(N, sizeof(int));
+        if (myArrays[thread].ISPLIT != NULL) myArrays[thread].ISPLIT[0]=N;
+    }
+
+    if (myArrays[thread].WORK   == NULL) myArrays[thread].WORK   = (plasma_complex64_t*) calloc(5*N, sizeof(plasma_complex64_t));
+    if (myArrays[thread].IWORK  == NULL) myArrays[thread].IWORK  = (int*) calloc(N, sizeof(int));
+    if (myArrays[thread].IFAIL  == NULL) myArrays[thread].IFAIL  = (int*) calloc(N, sizeof(int));
+    if (myArrays[thread].IBLOCK == NULL || 
+        myArrays[thread].ISPLIT == NULL || 
+        myArrays[thread].WORK   == NULL || 
+        myArrays[thread].IWORK  == NULL || 
+        myArrays[thread].IFAIL  == NULL) {
+        if(0) fprintf(stderr, "%2i:%s:%i zstein failed to allocate workspaces.\n", omp_get_thread_num(), __func__, __LINE__);
+        return(PlasmaErrorOutOfMemory);
+    }
+
+    plasma_complex64_t W = u;
+ 
+    zstein(&N, diag, offd, &M, &W, myArrays[thread].IBLOCK, myArrays[thread].ISPLIT, v, 
+            &LDZ, myArrays[thread].WORK, myArrays[thread].IWORK, myArrays[thread].IFAIL, &INFO);
+    if(0) fprintf(stderr, "%2i:%s:%i ev=%.16e zstein returning INFO=%d.\n", 
+                            omp_get_thread_num(), __func__, __LINE__, u, INFO);
+
+    return(INFO);
+} /* end useStein. */
+
+void plasma_zlaebz2(zlaebz2_WorkStack_t* Stack) {
+    plasma_complex64_t *diag = Stack->diag;
+    plasma_complex64_t *offd = Stack->offd;
+    int    N = Stack->N;
+ 
+    plasma_complex64_t cp;
+    int flag, evLess;
+    zlaebz2_EV_Bracket_t *myB;
+ 
+    while (1) {
+        flag = 0;
+        myB = NULL;
+        #pragma omp critical (UpdateStack)
+        {
+            if (Stack->finished == Stack->eigenvalues) flag=1;
+            else if (Stack->ToDo != NULL) {
+                myB = Stack->ToDo;
+                Stack->ToDo = myB->next;
+            }
+        }
+        
+        /* Exit, all the work is done. */
+        if (flag==1) return;
+        
+        /* If all the work isn't done but I couldn't find any,
+         * go back and look again. Another thread must still 
+         * be subdividing or working on a vector.
+         */
+        if (myB == NULL) continue;
+        
+        /* Okay, myB is popped off the stack, we must resolve it. */
+        switch (myB->stage) {
+            case PlasmaStageInit:
+                myB->nLT_low = plasma_zlaneg2(diag, offd, N, myB->lowerBound);
+                myB->nLT_hi =  plasma_zlaneg2(diag, offd, N, myB->upperBound);
+                /* compute number of eigenvalues in this range. */
+                myB->numEV = (myB->nLT_hi - myB->nLT_low);
+                if(0) fprintf(stderr, "%2i:%s:%i On entry, #EV in [%.7f, %.7f]==%d, nLT_low=%d, nLT_hi=%d.\n", omp_get_thread_num(), __func__, __LINE__, myB->lowerBound, myB->upperBound, myB->numEV, myB->nLT_low, myB->nLT_hi);
+                
+                /* If no eigenvalues in this bracket, we discard it and break
+                 * from the switch() to continue the while().  This happens when
+                 * ranges are part of the first arbitrary range division.
+                 */
+                if (myB->numEV == 0) {
+                    free(myB);  
+                    myB=NULL;
+                    break;
+                }
+                
+                if (Stack->range == PlasmaRangeI) {
+                    if (myB->nLT_hi  < Stack->il ||     /* e.g if il=500, and nLT_hi=499, this bracket is under range of interest. */
+                        myB->nLT_low > Stack->iu) {     /* e.g if iu=1000, and lLT_low=1001, this bracket is above range of interest. */
+                        if(0) fprintf(stderr, "Line:%i, discard myB, nLT_hi=%i, nLT_low=%i, Stack.il=%i, Stack.iu=%i, myB=%p.\n", 
+                        __LINE__, myB->nLT_hi, myB->nLT_low, Stack->il, Stack->iu, myB);
+                        free(myB);
+                        myB=NULL;
+                        break;
+                    }
+                }
+                
+                myB->stage = PlasmaStageBisection;
+                /* fall-thru into Bisection. */
+               
+            case PlasmaStageBisection:
+                flag = 0;
+                while (1) {
+                    cp = (myB->lowerBound+myB->upperBound)*0.5;
+                    if(0) fprintf(stderr, "%2i:%s:%i lowerBound=%.16f, upperBound=%.16f, cp=%.16f, nLT_low=%i, nLT_hi=%i.\n", 
+                            omp_get_thread_num(), __func__, __LINE__, myB->lowerBound, myB->upperBound, cp, myB->nLT_low, myB->nLT_hi);
+                    if (cp == myB->lowerBound || cp == myB->upperBound) {
+                        /* Our bracket has been narrowed to machine epsilon for this magnitude (=ulp). 
+                         * We are done; the bracket is always [low,high). 'high' is not included, so
+                         * we have myB->numEV eigenvalues at low, whether it == 1 or is > 1. We find
+                         * the eigenvector. (We can test multiplicity with GluedWilk).
+                         */
+
+                        if(0) fprintf(stderr, "%2i:%s:%i cutpoint found eigenvalue %.16e nLT_low=%d idx=%d numEV=%i.\n", omp_get_thread_num(), __func__, __LINE__, myB->lowerBound, myB->nLT_low, myB->nLT_low - Stack->baseIdx, myB->numEV);
+                        break;
+                    } else {
+                        /* we have a cutpoint. */
+                        evLess = plasma_zlaneg2(diag, offd, N, cp);
+                        if(0) fprintf(stderr, "%2i:%s:%i cp=%.16f, evLess<cp=%i, nLT_low=%i, nLT_hi=%i.\n", 
+                            omp_get_thread_num(), __func__, __LINE__, cp, evLess, myB->nLT_low, myB->nLT_hi);
+                        if (evLess < 0) {
+                            /* We could not compute the Sturm sequence for it. */
+                            flag = -1; /* indicate an error. */
+                            if(0) fprintf(stderr, "Sturm Sequence compute fails for this matrix.\n");
+                            break; /* exit while true. */
+                        }
+                    
+                        /* Discard empty halves in both PlasmaRangeV and PlasmaRangeI.
+                         * If #EV < cutpoint is the same as the #EV < high, it means
+                         * no EV are in [cutpoint, hi]. We can discard that range.
+                         */
+
+                        if (evLess == myB->nLT_hi) {
+                            myB->upperBound = cp;
+                            if(0) fprintf(stderr, "%2i:%s:%i cp=%.16f Discard high range, now [%.16f, %.16f].\n", omp_get_thread_num(), __func__, __LINE__, cp, myB->lowerBound, myB->upperBound);
+                            continue;
+                        }
+                    
+                        /* If #EV < cutpoint is the same as #EV < low, it means no
+                         * EV are in [low, cutpoint]. We can discard that range. 
+                         */
+
+                        if (evLess == myB->nLT_low) {
+                            myB->lowerBound = cp;
+                            if(0) fprintf(stderr, "%2i:%s:%i cp=%.16f Discard Low range, now [%.16f, %.16f].\n", omp_get_thread_num(), __func__, __LINE__, cp, myB->lowerBound, myB->upperBound);
+                            continue;
+                        }
+                    
+                        /* Note: If we were PlasmaRangeV, the initial bounds given by the user are the ranges,
+                         * so we have nothing further to do. In PlasmaRangeI; the initial bounds are Gerschgorin,
+                         * limits and not enough: We must further narrow to the desired indices.
+                         */
+
+                        if (Stack->range == PlasmaRangeI) {
+                            if(0) fprintf(stderr, "%2i:%s:%i PlasmaRangeI cp=%.16f, evLess=%i, Stack->il=%i, Stack->iu=%i.\n", 
+                              omp_get_thread_num(), __func__, __LINE__, cp, evLess, Stack->il, Stack->iu);
+
+                            /* For PlasmaRangeI:
+                             * Recall that il, iu are 1-relative; while evLess is zero-relative; i.e.
+                             * if [il,iu]=[1,2], evless must be 0, or 1. 
+                             * when evLess<cp == il-1, or just <il, cp is a good boundary and 
+                             * we can discard the lower half.
+                             *
+                             * To judge the upper half, the cutpoint must be < iu, so if it is >= iu,
+                             * cannot contain eigenvalue[iu-1].
+                             * if evLess >= iu, we can discard upper half.
+                             */
+
+                            if (evLess < Stack->il) {
+                                /* The lower half [lowerBound, cp) is not needed, it has no indices >= il. */
+                                myB->lowerBound = cp;
+                                myB->nLT_low    = evLess;
+                                myB->numEV = (myB->nLT_hi-myB->nLT_low);
+                                if(0) fprintf(stderr, "%2i:%s:%i cp=%.16f PlasmaRangeI: Discard Low range, now [%.16f, %.16f] #Eval=%i.\n", omp_get_thread_num(), __func__, __LINE__, cp, myB->lowerBound, myB->upperBound, myB->numEV);
+                                continue;
+                            }
+                    
+                            if (evLess >= Stack->iu) {
+                                /* The upper half [cp, upperBound) is not needed, it has no indices > iu; */
+                                myB->upperBound = cp;
+                                myB->nLT_hi     = evLess;
+                                myB->numEV = (myB->nLT_hi-myB->nLT_low);
+                                if(0) fprintf(stderr, "%2i:%s:%i cp=%.16f PlasmaRangeI: Discard High range, now [%.16f, %.16f] #Eval=%i.\n", omp_get_thread_num(), __func__, __LINE__, cp, myB->lowerBound, myB->upperBound, myB->numEV);
+                                continue;
+                            }
+                        } /*end if index search. */
+                    
+                        /* Here, the cutpoint has some valid EV on the left and some on the right. */
+                        if(0) fprintf(stderr, "%2i:%s:%i splitting Bracket [%.16f,%.16f,%.16f], nLT_low=%i,nLT_cp=%i,nLT_hi=%i\n", 
+                               omp_get_thread_num(), __func__, __LINE__, myB->lowerBound, cp, myB->upperBound, myB->nLT_low, evLess, myB->nLT_hi);
+                        zlaebz2_EV_Bracket_t* newBracket = (zlaebz2_EV_Bracket_t*) calloc(1, sizeof(zlaebz2_EV_Bracket_t)); 
+                        memcpy(newBracket, myB, sizeof(zlaebz2_EV_Bracket_t));
+                        /* the right side: Low is cp; Hi stays the same; stage is still Bisection. */
+                        newBracket->lowerBound = cp;
+                        newBracket->nLT_low = evLess;
+                        newBracket->numEV = (myB->nLT_hi - evLess);
+                        #pragma omp critical (UpdateStack)
+                        {
+                            /* make new Bracket head of the ToDo work, */
+                            newBracket->next = Stack->ToDo;
+                            Stack->ToDo = newBracket;
+                        }
+                    
+                        /* Update the Bracket I kept. */               
+                        myB->upperBound = cp;
+                        myB->nLT_hi = evLess;
+                        myB->numEV =( evLess - myB->nLT_low); 
+                        continue; 
+                     }
+                } /* end while(true) for Bisection. */
+                
+                /* When we are done Bisecting, we have an Eigenvalue; proceed to GetVector. */
+                if(0) fprintf(stderr, "%2i:%s:%i Exit while(true), found eigenvalue %.16e nLT_low=%d idx=%d numEV=%i.\n", omp_get_thread_num(), __func__, __LINE__, myB->lowerBound, myB->nLT_low, myB->nLT_low - Stack->baseIdx, myB->numEV);
+                myB->stage=PlasmaStageGetVector;
+                /* fall-thru to GetVector */
+            
+            case PlasmaStageGetVector:
+                if(0) fprintf(stderr, "%2i:%s:%i Getvector ev=%.16e idx=%d\n", omp_get_thread_num(), __func__, __LINE__, myB->lowerBound, myB->nLT_low-Stack->baseIdx);
+                /* Okay, count this eigenpair done, add to the Done list.
+                 * NOTE: myB->nLT_low is the global zero-relative index
+                 *       of this set of mpcity eigenvalues.
+                 *       No other brackets can change our entry, so we
+                 *       don't need any thread block or atomicity.
+                 */
+
+                int myIdx;
+                if (Stack->range == PlasmaRangeI) {
+                    myIdx = myB->nLT_low - (Stack->il-1);
+                } else { /* range == PlasmaRangeV */
+                    myIdx = myB->nLT_low - Stack->baseIdx;
+                }
+                
+                if (Stack->jobtype == PlasmaVec) {
+                    /* get the eigenvector. */
+                    int ret=useStein(diag, offd, myB->lowerBound, &(Stack->pVec[myIdx*N]), N, Stack->stein_arrays);
+                    if (ret != 0) {
+                        #pragma omp critical (UpdateStack)
+                        {
+                            if (Stack->error != 0) Stack->error = ret;
+                        }
+                    }
+                }
+                
+                /* Add eigenvalue and multiplicity. */
+                Stack->pVal[myIdx]=myB->lowerBound;
+                Stack->pMul[myIdx]=myB->numEV;
+                
+                if(0) fprintf(stderr, "%2i:%s:%i Success adding eigenvector #%d myIdx=%d of %d, value %.16f, mpcity=%d\n", omp_get_thread_num(), __func__, __LINE__, myB->nLT_low, myIdx, Stack->eigenvalues, myB->lowerBound, myB->numEV);
+                #pragma omp atomic 
+                    Stack->finished += myB->numEV;
+                
+                /* Done with this bracket. */
+                free(myB);
+                break;
+        } /* End switch on stage. */
+    } /* end Master Loop. */
+ 
+    if(0) fprintf(stderr, "%2i:%s:%i Exiting plasma_zlaebz2.\n", omp_get_thread_num(), __func__, __LINE__);
+} /* end plasma_zlaebz2 */
+

--- a/compute/zlaneg2.c
+++ b/compute/zlaneg2.c
@@ -1,0 +1,138 @@
+/**
+ *
+ * @file 
+ *
+ *  PLASMA is a software package provided by:
+ *  University of Tennessee, US,
+ *  University of Manchester, UK.
+ *
+ * @precisions normal z -> s d 
+ *
+ **/
+
+/*
+ * This file is a z-template to generate s and d code.
+ * Only s and d are compiled; not c or z. 
+ */
+ 
+/******************************************************************************
+ * This is the scaled Sturm; based on the classic Sturm.
+ * See https://archive.siam.org/meetings/la03/proceedings/zhangjy3.pdf
+ * "J. Zhang, 2003, The Scaled Sturm Sequence Computation".
+ * Both the Sturm (proportional) and the classical Sturm can suffer from
+ * underflow and overflow for some problematic matrices; automatic rescaling
+ * avoids that; and using the classical Sturm avoids division (and checking to
+ * avoid division by zero). Computation is is still O(N), but about 1.5 times
+ * more flops.
+ *
+ * diag[0..n-1] are the diagonals; offd[0..n-2] are the offdiagonals.
+ * The classic recurrence: (u is the \lambda cutpoint in question).
+ * p[-1] = 1.;             // zero relative indexing.
+ * p[0] = diag[0] - u;
+ * p[i] = (diag[i]-u)*p[i-1] - offd[i-1]*offd[i-1]*p[i-2], i=1, N-1.
+ * 
+ * The Classical Sturm recurrence can be shown as a matrix computation; namely
+ * P[i] = M[i]*P[i-1]. Be careful of the i-1 index:
+ * M[i] = [(diag[i]-u) , -offd[i-1]*offd[i-1] ] and P[i-1] = [ p[i-1] ]
+ *        [          1 ,                    0 ]              [ p[i-2] ]
+ * with P[-1] defined to be [1, 0] transposed.
+ * notice 'p' is the classical Sturm, 'P' is a vector.
+ * 
+ * the matrix computation results in the vector: 
+ * M[i]*P[i-1] = { (diag[i]-u)*p[i-1] -offd[i-1]*offd[i-1]*p[i-2] , p[i-1] }
+ * 
+ * So, in the classical case, P[i][0] is the classic Sturm sequence for p[i];
+ * the second element is just the classic Sturm for p[i-1].
+ *
+ * However, this won't remain that way. For the SCALED Sturm sequence, we 
+ * will scale P[i] after each calculation, with the scalar 's': 
+ *
+ * *********************************
+ * P[i] = s * M[i]*P[i-1], i=0, N-1. Note we are scaling a vector here.
+ * *********************************
+ *
+ * For code, we represent P[i-1] as two scalars, [Pm1_0 , Pm1_1].
+ * The matrix calculation is thus:
+ * M[i]*P[i-1] = { (diag[i]-u)*Pm1_0 -offd[i-1]*offd[i-1]*Pm1_1 , Pm1_0 }
+ * or in three equations, adding in the scalar:
+ * save = s * Pm1_0;
+ * Pm1_0 = s * ( (diag[i]-u)*Pm1_0 -offd[i-1]*offd[i-1]*Pm1_1 );
+ * Pm1_1 = save;
+ 
+ * Pm1_0 is used like the classical Sturm sequence; meaning we must calculate
+ * sign changes.
+ * 
+ * s is computed given the vector X[] = M[i]*P[i-1] above.
+ * PHI is set to 10^{10}, UPSILON is set to 10^{-10}. Then:
+ *    w = max(fabs(X[0]), fabs(X[1])). 
+ *    if w > PHI then s = PHI/w;
+ *    else if w < UPSILON then s = UPSILON/w;
+ *    else s=1.0 (or, do not scale X).
+ * 
+ * This algorithm is backward stable. execution time is 1.5 times classic Sturm.
+ * 
+ * No sign change counts eigenvalues >= u.
+ * sign changes count eigenvalues <  u.
+ * This routine returns the number of sign changes, which is the count of
+ * eigenvalues strictly less than u.
+ * 
+ * computation: What we need for each computation:
+ * M[i], which we compute on the fly from diag[i] and offd[i-1].
+ * P[i-1], which has two elements, [Pm1_0, Pm1_1]. (Pm1 means P minus 1).
+ * LAPACK routine DLAEBZ computes a standard Sturm sequences; there is no 
+ * comparable auto-scaling Sturm sequence.
+ *
+ * This routine is most similar to LAPACK DLANEG.f, but is not a replacement
+ * for it. DLANEG.f does not autoscale.
+ *
+ * Arguments:
+ * diag: a pointer to the 'n' diagonal elements.
+ * offd: a pointer to the 'n-1' off-diagonal elements.
+ * n   : The order of the matrix.
+ * u   : the sigma test point.
+ *****************************************************************************/
+
+#include <math.h>
+
+int plasma_zlaneg2(plasma_complex64_t *diag, plasma_complex64_t *offd, int n, plasma_complex64_t u) {
+    int i, isneg=0;
+    plasma_complex64_t s, w, v0, v1, Pm1_0, Pm1_1, PHI, UPSILON;
+    if (n==0) return (0);
+    PHI = ((plasma_complex64_t)(((long long) 1)<<34));
+    UPSILON = 1.0/PHI;
+ 
+    Pm1_1 = 1.0;
+    Pm1_0 = (diag[0]-u);
+    if (Pm1_0 < 0) isneg = 1;  /* our first test. */
+    for (i=1; i<n; i++) {
+        /* first part of scaling, just get w. */
+        v0 = fabs(Pm1_0);
+        v1 = fabs(Pm1_1);
+        if (v0 > v1) w = v0;
+        else         w = v1;
+ 
+        /*Go ahead and calculate P[i]: */
+        s = Pm1_0;
+        Pm1_0 = (diag[i]-u)*Pm1_0 -((offd[i-1]*offd[i-1])*Pm1_1);
+        Pm1_1 = s;
+ 
+        /* Now determine whether to scale these new values. */
+        if (w > PHI) {
+            s = PHI/w;
+            Pm1_0 *= s;
+            Pm1_1 *= s;
+        } else if (w < UPSILON) {
+            s = UPSILON/w;
+            Pm1_0 *= s;
+            Pm1_1 *= s;
+        } /* else skip scaling. */
+ 
+        /* Finally, see if the sign changed. */
+        if ( (Pm1_0 < 0 && Pm1_1 >= 0) ||  
+             (Pm1_0 >= 0 && Pm1_1 < 0)
+           ) isneg++;  
+    }
+             
+    return(isneg);
+} /* end plasma_zlaneg2 */
+

--- a/compute/zstevx2.c
+++ b/compute/zstevx2.c
@@ -1,0 +1,584 @@
+/**
+ *
+ * @file 
+ *
+ *  PLASMA is a software package provided by:
+ *  University of Tennessee, US,
+ *  University of Manchester, UK.
+ *
+ * @precisions normal z -> s d 
+ *
+ **/
+
+/*
+ * This file is a z-template to generate s and d code.
+ * Only s and d are compiled; not c or z. 
+ */
+ 
+#include "plasma.h"
+#include "plasma_internal.h"     /* needed for imin, imax. */
+#include "plasma_zlaebz2_work.h" /* work areas. */
+
+#include <string.h>
+#include <omp.h>
+#include <math.h>
+#include <float.h>
+#include "mkl_lapack.h"
+/* core_lapack.h gives us plasma_zgeqrf; which is 10x slower than MKL's zgeqrf. */
+/* #include "core_lapack.h" */
+/* #include "lapack.h" */
+
+/*******************************************************************************
+ *
+ * @ingroup plasma_stevx2
+ * Symmetric Tridiagonal Eigenvalues/pairs by range.
+ *
+ * Computes a caller-selected range of eigenvalues and, optionally,
+ * eigenvectors of a symmetric tridiagonal matrix A.  Eigenvalues and
+ * eigenvectors can be selected by specifying either a range of values or a
+ * range of indices for the desired eigenvalues.
+ *
+ * This is similiar to LAPACK dstevx, with more output parameters. 
+ *
+ * Because input matrices are expected to be extremely large and the exact
+ * number of eigenvalues is not necessarily known to the caller, this routine
+ * provides a way to get the number of eigenvalues in either a value range or
+ * an index range; so the caller can allocate the return arrays. There are
+ * three; the floating point vector pVal, the integer vector pMul, and the
+ * floating point matrix pVec, which is only required and only referenced for 
+ * jobtype=PLasmaVec.
+ *
+ * When the jobtype=PlasmaCount; the code returns the maximum number of
+ * eigenvalues in the caller-selected range in pFound (an integer pointer).
+ *
+ * However, upon return from jobtype=PlasmaVec or jobtype=PlasmaNoVec, the code
+ * returns the number of unique eigenvalues found in pFound. For a symmetric
+ * matrix the maximum number of eigenvaues and the unique eigenvalues found
+ * should be equal; but due to the limits of machine precision, multiple
+ * arithmetically unique eigenvalue may be approximated by the same floating
+ * point number. In that case, to the machine this looks like a multiplicity;
+ * and we report it that way. We see this phenomenon in large (e.g. N=50000)
+ * test matrices, for example. Our tester uses Kahan matrices, because the
+ * eigenvalues are directly computable, between -2.0 and +2.0; and at N=50000 
+ * vl=1.5, vu=2.0, we do get a multiplicities up to 6.
+ *
+ * Finding eigenvalues alone is much faster than finding eigenpairs; the
+ * majority of the time consumed when eigenvectors are found is in
+ * orthogonalizing the eigenvectors; an O(N*K^2) operation. 
+ *******************************************************************************
+
+ *
+ * @param[in] jobtype
+ *          enum:
+ *          = PlasmaNoVec: computes eigenvalues only;
+ *          = PlasmaVec:   computes eigenvalues and eigenvectors.
+ *          = PlasmaCount: computes pFound as the max number of eigenvalues/pairs
+ *                         in the given range, so user can allocate 
+ *                         pVal[Found], pMult[Found], pVec[n x Found].
+ *
+ * @param[in] range
+ *          enum:
+ *          PlasmaRangeV use vl, vu for range [vl, vu)
+ *          PlasmaRangeI use il, iu for range [il, iu]. 1-relative; 1..N. 
+ *
+ * @param[in] n
+ *          int. The order of the matrix A. n >= 0.
+ *
+ * @param[in] k
+ *          int. The space the user has allocated for eigenvalues; as reflected in
+ *          pVal, pMul, pVec. 
+ *
+ * @param[in] diag
+ *          double[n]. Vector of [n] diagonal entries of A. 
+ *
+ * @param[in] offd
+ *          double[n-1]. A vector of [n-1] off-diagonal entries of A.
+ *
+ * @param[in] vl   
+ *          double. Lowest eigenvalue in desired range [vl, vu).
+ *          if less than Gerschgorin min; we use Gerschgorin min.
+ *
+ * @param[in] vu
+ *          double. Highest eigenvalue in desired range, [vl,vu).
+ *          if greater than Gerschgorin max, we use Gerschgorin max+eps.
+ *
+ * @param[in] il
+ *          int. Low Index of range. Must be in range [1,n].
+ *
+ * @param[in] iu
+ *          int. High index of range. Must be in range [1,n], >=il.
+ *
+ * @param[out] pFound
+ *          int*. On exit, the number of distinct eigenvalues (or pairs) found.
+ *          Due to machine-precision multiplicity, may be less than the maximum
+ *          number of eigenvalues in the user's range.
+ *          For jobtype=PlasmaCount, the maximum number of distinct
+ *          eigenvalues in the interval selected by range, [vl,vu) or [il,iu].
+ *
+ * @param[out] pVal
+ *          double*. expect double Val[k]. The first 'found' elements are the 
+ *          found eigenvalues.
+ *
+ * @param[out] pMul
+ *          int*. expect int Mul[k]. The first 'found' elements are the 
+ *          multiplicity values.
+ *
+ * @param[out] pVec
+ *          double*. Expect double Vec[n*k]. the first ('n'*'found') elements 
+ *          contain an orthonormal set of 'found' eigenvectors, each of 'n'
+ *          elements, in column major format. e.g. eigenvector j is found in
+ *          Vec[n*j+0] ... Vec[n*j+n-1]. It corresponds to eigenvalue Val[j],
+ *          with multiplicity Mul[j].
+ *          if jobtype=PlasmaNoVec, then pVec is not referenced.
+ *
+ *******************************************************************************
+ *
+ * @retval PlasmaSuccess successful exit
+ * @retval < 0 if -i, the i-th argument had an illegal value
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Finds the least and largest signed eigenvalues (not least magnitude).
+ * begins with bounds by Gerschgorin disc. These may be over or under
+ * estimated; Gerschgorin only ensures a disk will contain each. Thus we then
+ * use those with bisection to find the actual minimum and maximum eigenvalues.
+ * Note we could find the least magnitude eigenvalue by bisection between 0 and
+ * each extreme value.
+ * By Gerschgorin Circle Theorem;
+ * All Eigval(A) are \in [\lamda_{min}, \lambda_{max}].
+ * \lambda_{min} = min (i=0; i<n) diag[i]-|offd[i]| - |offd[i-1]|,
+ * \lambda_{max} = max (i=0; i<n) diag[i]+|offd[i]| + |offd[i-1]|,
+ * with offd[-1], offd[n] = 0.
+ * Indexes above are 0 relative.
+ * Although Gerschgorin is mentioned in ?larr?.f LAPACK files, it is coded
+ * inline there. 
+ *****************************************************************************/
+
+static void Bound_MinMax_Eigvalue(plasma_complex64_t *diag, 
+            plasma_complex64_t *offd, int n, plasma_complex64_t *Min, 
+            plasma_complex64_t *Max) {
+    int i;
+    plasma_complex64_t test, testdi, testdim1, min=DBL_MAX, max=-DBL_MAX;
+ 
+    for (i=0; i<n; i++) {
+        if (i == 0) testdim1=0.;
+        else        testdim1=offd[i-1];
+        
+        if (i==(n-1)) testdi=0;
+        else          testdi=offd[i];
+        
+        test=diag[i] - fabs(testdi) - fabs(testdim1);
+        if (test < min) {
+            min=test;
+            if(0) fprintf(stderr,"Gerschgorin row=%i new min=%.16e.\n", i, min);
+        } 
+        
+        test=diag[i] + fabs(testdi) + fabs(testdim1);
+        if (test > max) {
+            max=test;
+            if(0) fprintf(stderr,"Gerschgorin row=%i new max=%.16e.\n", i, max);
+        }      
+    }
+       
+ 
+    plasma_complex64_t cp, minLB=min, minUB=max, maxLB=min, maxUB=max;
+    /* Now, within that range, find the actual minimum. */
+    while (1) {
+        cp = (minLB+minUB)*0.5;
+        if (cp == minLB || cp == minUB) break;
+        if (plasma_zlaneg2(diag, offd, n, cp) == n) minLB = cp;
+        else                                      minUB = cp;
+    }
+     
+    /* Now find the max within that range. At each midpoint MidP: */
+    while (1) {
+        cp = (maxLB+maxUB)*0.5;
+        if (cp == maxLB || cp == maxUB) break;
+        if (plasma_zlaneg2(diag, offd, n, cp) == n) {
+            if(0) fprintf(stderr,"maxLB=%.16e maxUB=%.16e new maxUB=cp=%.16e.\n", maxLB, maxUB, cp);
+            maxUB=cp;
+        } else {
+            if(0) fprintf(stderr,"maxLB=%.16e maxUB=%.16e new maxLB=cp=%.16e.\n", maxLB, maxUB, cp);
+            maxLB=cp;
+        }
+    }
+ 
+    *Min = minLB;
+    *Max = maxUB;
+} /* end Bound_MinMax_Eigvalue */
+
+/******************************************************************************
+ * Matrix multiply; A * X = Y.
+ * A = [diag[0], offd[0], 
+ *     [offd[0], diag[1], offd[1]
+ *     [      0, offd[1], diag[2], offd[2],
+ *     ...
+ *     [ 0...0                     offd[n-2], diag[n-1] ]
+ * LAPACK does not do just Y=A*X for a packed symmetric tridiagonal matrix.
+ * This routine is necessary to determine if eigenvectors should be swapped.
+ *****************************************************************************/
+
+static void MM(plasma_complex64_t *diag, plasma_complex64_t *offd, int n, 
+            plasma_complex64_t *X, plasma_complex64_t *Y) {
+    int i;
+    Y[0] = diag[0]*X[0] + offd[0]*X[1];
+    Y[n-1] = offd[n-2]*X[n-2] + diag[n-1]*X[n-1];
+ 
+    for (i=1; i<(n-1); i++) {
+        Y[i] = offd[i-1]*X[i-1] + diag[i]*X[i] + offd[i]*X[i+1];
+    }
+} /* END MM. */
+
+
+/******************************************************************************
+ * This routine is necessary to determine if eigenvectors should be swapped.
+ * eigenpair error: If A*v = u*v, then A*v-u*v should == 0. We compute the
+ * L_infinity norm of (A*v-u*v).
+ * We return DBL_MAX if the eigenvector (v) is all zeros, or if we fail to 
+ * allocate memory. 
+ * If u==0.0, we'll return L_INF of (A*V). 
+ *****************************************************************************/
+
+static plasma_complex64_t eigp_error(plasma_complex64_t *diag, 
+       plasma_complex64_t *offd, int n, plasma_complex64_t u, 
+       plasma_complex64_t *v) {
+    int i, zeros=0;
+    plasma_complex64_t *AV;
+    plasma_complex64_t norm, dtemp;
+ 
+    AV = (plasma_complex64_t*) calloc(n, sizeof(plasma_complex64_t));
+    if (AV == NULL) return(DBL_MAX);
+     
+    MM(diag, offd, n, v, AV); /* AV = A*v. */
+ 
+    norm = -DBL_MAX;  /* Trying to find maximum. */
+    zeros=0;
+    for (i=0; i<n; i++) {
+        dtemp = fabs(AV[i] - u*v[i]);    /* This should be zero. */
+        if (dtemp > norm) norm=dtemp;
+        if (v[i] == 0.) zeros++;
+    }
+ 
+    free(AV);
+    if (zeros == n) return(DBL_MAX);
+    return(norm);
+} /* end eigp_error. */
+
+
+/******************************************************************************
+ * This is the main routine; plasma_zstevx2 
+ *****************************************************************************/
+int plasma_zstevx2(
+  /* args 1,2  */ plasma_enum_t jobtype, plasma_enum_t range,
+  /* args 3,4  */ int n, int k,
+  /* arg 5     */ plasma_complex64_t *diag,
+  /* arg 6     */ plasma_complex64_t *offd,
+  /* arg 7     */ plasma_complex64_t vl,
+  /* arg 8     */ plasma_complex64_t vu,
+  /* args 9,10,*/ int il, int iu,
+  /* arg 11    */ int *pFound,
+  /* arg 12    */ plasma_complex64_t *pVal,
+  /* arg 13    */ int    *pMul,
+  /* arg 14    */ plasma_complex64_t *pVec)
+{
+    int i, max_threads;
+    zlaebz2_Stein_Array_t *stein_arrays = NULL;
+    /* Get PLASMA context. */
+    plasma_context_t *plasma = plasma_context_self();
+    if (plasma == NULL) {
+        plasma_fatal_error("PLASMA not initialized");
+        return PlasmaErrorNotInitialized;
+    }
+
+    /* Check input arguments */
+    if (jobtype != PlasmaVec && jobtype != PlasmaNoVec && jobtype != PlasmaCount) {
+        plasma_error("illegal value of jobtype");
+        return -1;
+    }
+    if (range != PlasmaRangeV &&
+        range != PlasmaRangeI ) {
+        plasma_error("illegal value of range");
+        return -2;
+    }
+    if (n < 0) {
+        plasma_error("illegal value of n");
+        return -3;
+    }
+
+    /* arg 4: Any value of 'k' is legal on entry, we check it later. */
+
+    if (diag == NULL) {
+        plasma_error("illegal pointer diag");
+        return -5;
+    }
+    if (offd == NULL) {
+        plasma_error("illegal pointer offd");
+        return -6;
+    }
+    
+    /* Check args 7, 8. */
+    if (range == PlasmaRangeV && vu <= vl ) {
+        plasma_error("illegal value of vl and vu");
+        return -7;
+    }
+
+    /* check args 9, 10. */
+    if (range == PlasmaRangeI) {
+        if (il < 1 || il > imax(1,n)) {
+             plasma_error("illegal value of il");
+             return -9;
+        } else if (iu < imin(n,il) || iu > n) {
+            plasma_error("illegal value of iu");
+            return -10;
+        }
+    }
+
+    if (pFound == NULL) return -11;
+
+    /* Quick return */
+    if (n == 0) {
+        pFound[0]=0;
+        return PlasmaSuccess;
+    }
+
+    max_threads = omp_get_max_threads();
+
+    if (jobtype == PlasmaVec) { 
+        stein_arrays = (zlaebz2_Stein_Array_t*) calloc(max_threads, sizeof(zlaebz2_Stein_Array_t));
+        if (stein_arrays == NULL) {
+            return PlasmaErrorOutOfMemory;
+        }
+    }
+        
+    /* Initialize sequence. */
+    plasma_sequence_t sequence;
+    plasma_sequence_init(&sequence);
+
+    /* Initialize request. */
+    plasma_request_t request;
+    plasma_request_init(&request);
+
+    plasma_complex64_t globMinEval, globMaxEval; 
+
+    zlaebz2_WorkStack_t workStack;
+    memset(&workStack, 0, sizeof(zlaebz2_WorkStack_t)); 
+    workStack.N = n;
+    workStack.diag = diag;
+    workStack.offd = offd;
+    workStack.jobtype = jobtype;
+    workStack.range = range;
+    workStack.il = il;
+    workStack.iu = iu;
+    workStack.stein_arrays = stein_arrays;
+
+    /* Find actual min and max eigenvalues. */
+    Bound_MinMax_Eigvalue(workStack.diag, workStack.offd, workStack.N, &globMinEval, &globMaxEval);
+    if (0) fprintf(stderr, "%s:%i globMinEval=%.15f, globMaxEval=%.15f, vl=%.15f vu=%.15f\n",
+           __func__, __LINE__, globMinEval, globMaxEval, vl, vu);
+
+    int evLessThanVL=0, evLessThanVU=n, nEigVals=0;
+    if (range == PlasmaRangeV) {
+        /* We don't call Sturm if we already know the answer. */
+        if (vl >= globMinEval) evLessThanVL=plasma_zlaneg2(diag, offd, n, vl);
+        else vl = globMinEval; /* optimize for computing step size. */
+
+        if (vu <= globMaxEval) evLessThanVU=plasma_zlaneg2(diag, offd, n, vu);
+        else vu = nexttoward(globMaxEval, DBL_MAX);  /* optimize for computing step size */
+        /* Compute the number of eigenvalues in [vl, vu). */
+        nEigVals = (evLessThanVU - evLessThanVL);
+        if (0) fprintf(stderr, "%s:%i evLessThanVU=%i, evLessThanVL=%i, nEigVals=%i.\n", 
+               __func__, __LINE__, evLessThanVU, evLessThanVL, nEigVals);
+
+         workStack.baseIdx = evLessThanVL;
+    } else {
+        /* PlasmaRangeI: iu, il already vetted by code above. */
+        nEigVals = iu+1-il; /* The range is inclusive. */
+        /* We still bisect by values to discover eigenvalues, though. */
+        vl = globMinEval;
+        vu = nexttoward(globMaxEval, DBL_MAX); /* be sure to include globMaxVal. */
+        workStack.baseIdx = 0; /* There are zero eigenvalues less than vl. */
+    }
+
+    /* if we just need to find the count of eigenvalues in a value range, */
+    if (jobtype == PlasmaCount) {
+        pFound[0] = nEigVals;
+        return(PlasmaSuccess);
+    }
+
+    /* Now if user's K (arg 4) isn't enough room, we have a problem. */
+    if (k < nEigVals) {
+        return -4;             /* problem with user's K value. */
+    }   
+
+    /* We are going into discovery. Make sure we have arrays. */
+    if (pVal == NULL) return -12;   /* pointers cannot be null. */
+    if (pMul == NULL) return -13;
+    if (jobtype == PlasmaVec && pVec == NULL) return -14;   /* If to be used, cannot be NULL. */
+
+    /* handle value range. */
+    /* Set up workStack controls. */
+    workStack.eigenvalues = nEigVals;
+    workStack.finished = 0;
+    workStack.pVal = pVal;
+    workStack.pMul = pMul;
+    workStack.pVec = pVec;
+    
+    /* Create a bracket per processor to kick off the work stack.
+     * here, low and high are the range values.
+     * We need low+max_threads*step = hi-step. ==>
+     * (hi-low) = step*(max_threads+1) ==>
+     * step = (hi-low)/(max_threads+1).
+     */
+
+    plasma_complex64_t step = (vu - vl)/(max_threads+1);
+    plasma_complex64_t prevUpper = vl;
+    for (i=0; i<max_threads; i++) {
+        zlaebz2_EV_Bracket_t *thisBracket = (zlaebz2_EV_Bracket_t*) calloc(1, sizeof(zlaebz2_EV_Bracket_t));
+        thisBracket->stage = PlasmaStageInit;
+        thisBracket->lowerBound = prevUpper;
+        if (i == max_threads-1) thisBracket->upperBound = vu;
+        else                    thisBracket->upperBound = thisBracket->lowerBound + step;
+        prevUpper = thisBracket->upperBound; /* don't rely on arithmetic for final value. */
+        thisBracket->nLT_low = -1;
+        thisBracket->nLT_hi  = -1;
+        thisBracket->numEV   = -1;
+    
+        /* Now add to the workstack. OMP not active yet. */          
+        thisBracket->next = workStack.ToDo;
+        workStack.ToDo = thisBracket;
+    }
+
+    /* We can launch the threads. */
+    #pragma omp parallel /* proc_bind(close) requires gcc >=4.9. */
+    {
+       plasma_zlaebz2(&workStack);
+    }
+ 
+    /* Now, all the eigenvalues should have unit eigenvectors in the array workStack.Done.
+     * We don't need to sort that, but we do want to compress it; in case of multiplicity.
+     * We compute the final number of eigenvectors in vectorsFound, and mpcity is recorded.
+     */
+    int vectorsFound = 0;
+    for (i=0; i<workStack.eigenvalues; i++) {
+        if (pMul[i] > 0) {
+            vectorsFound++;
+        }
+    }
+
+    /* record for user. */
+    pFound[0] = vectorsFound;
+
+    /* compress the array in case vectorsFound < nEigVals (due to multiplicities).    */
+    /* Note that pMul[] is initialized to zeros, if still zero, a multiplicity entry. */
+    if (vectorsFound < workStack.eigenvalues) {
+        int j=0;   
+        for (i=0; i<workStack.eigenvalues; i++) {
+            if (pMul[i] > 0) {                          /* If this is NOT a multiplicity, */
+                pMul[j] = pMul[i];                      /* copy to next open slot j       */
+                pVal[j] = pVal[i];      
+                if (workStack.jobtype == PlasmaVec) {
+                    if (j != i) {
+                        memcpy(&pVec[j*workStack.N], &pVec[i*workStack.N], workStack.N*sizeof(plasma_complex64_t));
+                    }
+                }
+
+                j++;
+            } /* end if we found a non-multiplicity eigenvalue */
+        }
+    } /* end if compression is needed. */
+
+    double orth_s;
+    double start_orth;
+    int ret;
+
+    /* perform QR factorization, remember the descriptor. */
+    plasma_desc_t T;
+
+    if (0) start_orth = omp_get_wtime();
+    ret = plasma_zgeqrf(workStack.N, vectorsFound, /* This leaves pVec in compressed state of Q+R */
+                  pVec, workStack.N, &T);
+    if (ret != 0) {
+        fprintf(stderr, "%s:%i ret=%i for plasma_zqeqrf.\n", __func__, __LINE__, ret);
+        exit(-1);
+    }
+
+    /* extract just the Q of the QR, in normal form, in workspace pQ */
+    plasma_complex64_t* pQ = (plasma_complex64_t*) calloc(workStack.N*vectorsFound, sizeof(plasma_complex64_t));
+    ret = plasma_zungqr(workStack.N, vectorsFound, vectorsFound,
+                  pVec, workStack.N, T, pQ, workStack.N);
+
+    if (ret != 0) {
+        fprintf(stderr, "%s:%i ret=%i for plasma_zungqr.\n", __func__, __LINE__, ret);
+        exit(-1);
+    }
+
+    /* copy orthonormal vectors from workspace pQ to pVec for user return. */
+    memcpy(pVec, pQ, workStack.N*vectorsFound*sizeof(plasma_complex64_t));
+    {free(pQ); pQ = NULL;}
+
+    if (0) {
+        orth_s = (omp_get_wtime() - start_orth);
+        fprintf(stderr, "%s:%i plasma_qrf=%.6f sec\n", __func__, __LINE__, orth_s);
+    }
+
+    /*************************************************************************
+     * When eigenvalue are crowded, it is possible that after orthogonalizing
+     * vectors, it can be better to swap neighboring eigenvectors. We just 
+     * test all the pairs; basically ||(A*V-e*V)||_max is the error.  if BOTH 
+     * vectors in a pair have less error by being swapped, we swap them.
+     ************************************************************************/
+    int swaps=0;
+    if (jobtype == PlasmaVec) {
+        int N = workStack.N; 
+        plasma_complex64_t *Y = calloc(N, sizeof(plasma_complex64_t));
+        plasma_complex64_t *test = calloc(4, sizeof(plasma_complex64_t));
+        for (i=0; i<vectorsFound-1; i++) {
+            if (fabs(pVal[i+1]-pVal[i]) > 1.E-11) continue;
+
+            /* We've tried to parallelize the following four tests
+             * as four omp tasks. It works, but takes an average of
+             * 8% longer (~3.6 ms) than just serial execution. 
+             * omp schedule and taskwait overhead, I presume.
+             */
+
+            test[0]= eigp_error(workStack.diag, workStack.offd, N,
+                    pVal[i], &pVec[i*N]);
+            test[1] = eigp_error(workStack.diag, workStack.offd, N,
+                    pVal[i+1], &pVec[(i+1)*N]);
+            
+            test[2] = eigp_error(workStack.diag, workStack.offd, N,
+                    pVal[i], &pVec[(i+1)*N]);
+            test[3] = eigp_error(workStack.diag, workStack.offd, N,
+                    pVal[i+1], &pVec[i*N]);
+            
+            if ( (test[2] < test[0])         /* val1 with vec2 beats val1 with vec1 */
+              && (test[3] < test[1]) ) {     /* val2 with vec1 beats val2 with vec2 */
+                if(0) fprintf(stderr, "%s:%i Swapping vectors for %d and %d; eigenvalue diff=%.16e.\n", __func__, __LINE__, i, i+1, pVal[i+1]-pVal[i] );
+                memcpy(Y, &pVec[i*N], N*sizeof(plasma_complex64_t));
+                memcpy(&pVec[i*N], &pVec[(i+1)*N], N*sizeof(plasma_complex64_t));
+                memcpy(&pVec[(i+1)*N], Y, N*sizeof(plasma_complex64_t));
+                swaps++;
+            }
+        } /* end swapping. */
+
+        if (test) free(test);
+        if (Y) free(Y);
+    } /* end if we want to swap at all. */
+
+    /* Free all the blocks that got used. */
+    for (i=0; i<max_threads; i++) {
+       if (stein_arrays[i].IBLOCK) free(stein_arrays[i].IBLOCK);
+       if (stein_arrays[i].ISPLIT) free(stein_arrays[i].ISPLIT);
+       if (stein_arrays[i].WORK  ) free(stein_arrays[i].WORK  );
+       if (stein_arrays[i].IWORK ) free(stein_arrays[i].IWORK );
+       if (stein_arrays[i].IFAIL ) free(stein_arrays[i].IFAIL );
+    }
+
+    if (stein_arrays) free(stein_arrays);
+
+    /* Return status. */
+    if(0) fprintf(stderr, "plasma_stevx2 exit with return=%d.\n", sequence.status);
+    return sequence.status;
+} /* END plasma_zstevx2 */
+

--- a/include/plasma_types.h
+++ b/include/plasma_types.h
@@ -94,9 +94,6 @@ enum {
     PlasmaMaxNorm       = 177,
     PlasmaRealMaxNorm   = 178,
 
-    PlasmaEigVal        = 301,  // deprecated; same as PlasmaNoVec
-    PlasmaEigValVec     = 302,  // deprecated; same as PlasmaVec
-
     PlasmaNoVec         = 301,
     PlasmaVec           = 302,
     PlasmaCount         = 303,
@@ -154,6 +151,13 @@ enum {
     PlasmaInplaceOutplace,
     PlasmaNumPanelThreads,
     PlasmaHouseholderMode
+};
+
+/* State machine in stevx2. */
+enum {
+    PlasmaStageInit,
+    PlasmaStageBisection,
+    PlasmaStageGetVector
 };
 
 /******************************************************************************/

--- a/include/plasma_z.h
+++ b/include/plasma_z.h
@@ -17,6 +17,7 @@
 #include "plasma_barrier.h"
 #include "plasma_descriptor.h"
 #include "plasma_workspace.h"
+#include "plasma_zlaebz2_work.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -156,6 +157,11 @@ int plasma_zlacpy(plasma_enum_t uplo, plasma_enum_t transa,
                   plasma_complex64_t *pA, int lda,
                   plasma_complex64_t *pB, int ldb);
 
+void plasma_zlaebz2(zlaebz2_WorkStack_t* Stack);
+
+int plasma_zlaneg2(plasma_complex64_t *diag, plasma_complex64_t *offd, 
+                   int n, plasma_complex64_t u);
+
 double plasma_zlangb(plasma_enum_t norm,
                      int m, int n, int kl, int ku,
                      plasma_complex64_t *pAB, int ldab);
@@ -233,6 +239,19 @@ int plasma_zpotrs(plasma_enum_t uplo,
                   int n, int nrhs,
                   plasma_complex64_t *pA, int lda,
                   plasma_complex64_t *pB, int ldb);
+
+int plasma_zstevx2(
+  plasma_enum_t jobtype, plasma_enum_t range,
+  int n, int k,
+  plasma_complex64_t *diag,
+  plasma_complex64_t *offd,
+  plasma_complex64_t vl,
+  plasma_complex64_t vu,
+  int il, int iu,
+  int *pFound,
+  plasma_complex64_t *pVal,
+  int    *pMul,
+  plasma_complex64_t *pVec);
 
 int plasma_zsymm(plasma_enum_t side, plasma_enum_t uplo,
                  int m, int n,

--- a/include/plasma_zlaebz2_work.h
+++ b/include/plasma_zlaebz2_work.h
@@ -1,0 +1,83 @@
+/**
+ *
+ * @file
+ *
+ *  PLASMA header.
+ *  PLASMA is a software package provided by Univ. of Tennessee,
+ *  Univ. of Manchester, Univ. of California Berkeley and
+ *  Univ. of Colorado Denver.
+ *
+ * @precisions normal z -> s d c
+ *
+ **/
+#ifndef PLASMA_ZLAEBZ2_H
+#define PLASMA_ZLAEBZ2_H
+/******************************************************************************* 
+ * These structures support the ZLAEBZ2 code and ZSTEVX2 code, for eigenvalue 
+ * and eigenvector discovery.
+*******************************************************************************/
+
+/******************************************************************************* 
+ * This is a bracket for a range; any children are subdivisions of the range.
+ * We give each thread a bracket. The thread bisects the bracket until it has
+ * one eigenvalue, throwing off children in the chain as it does. Empty
+ * divisions are discarded; they won't be in the chain; e.g. if I divide the
+ * range in half and one half contains no eigenvalues, then we just update
+ * the existing bracket appropriately and divide again.
+*******************************************************************************/
+
+typedef struct
+{
+    int    stage;       /* stage of operations on this bracket. */
+    
+    plasma_complex64_t lowerBound;
+    plasma_complex64_t upperBound;
+    int    nLT_low;     /* # < lowerBound. -1 if it needs to be found.  */
+    int    nLT_hi;      /* # < upperBound. -1 if it needs to be found.  */
+    int    numEV;       /* number of Eigenvalues in bracket.            */
+    void   *next;       /* A bracket subdivides to more brackets.       */
+} zlaebz2_EV_Bracket_t;
+
+/******************************************************************************* 
+ * zstein needs work areas to function. Instead of allocating and deallocating
+ * these work areas for every vector, we provide a set of work areas per thread.
+ * They are allocated as needed; so we don't allocate more often than we need,
+ * and only allocate at most once per thread and not once per eigenvector.
+*******************************************************************************/
+
+typedef struct
+{
+    int     *IBLOCK;
+    int     *ISPLIT;
+    plasma_complex64_t  *WORK;
+    int     *IWORK;
+    int     *IFAIL;
+} zlaebz2_Stein_Array_t;
+
+/******************************************************************************* 
+ * The work stack is the global repository or work to do. It is either a range 
+ * containing multiple eigenvalues that must be subdivided (into multiple units 
+ * of work) or a final eigenvalue that needs an eigenvector, and recording into
+ * the final return arrays. When the work stack is empty, discovery is done.
+*******************************************************************************/
+
+typedef struct
+{
+    int     baseIdx;            /* Number of EV less than user's low threshold. */
+    plasma_enum_t range;        /* PlasmaRangeV or PlasmaRangeI.                */
+    plasma_enum_t jobtype;      /* PlasmaNoVec, PlasmaVec, PlasmaCount          */
+    int     il, iu;             /* For PlasmaRangeI.                            */
+    int     eigenvalues;        /* total number of eigenvalues to find.         */
+    int     finished;           /* # of finished eigenvectors.                  */
+    plasma_complex64_t  *diag;  /* pointers the threads need.                   */
+    plasma_complex64_t  *offd;
+    int     N;
+    zlaebz2_EV_Bracket_t* ToDo; /* NULL or chain head of EVBrackets yet to do.  */
+    zlaebz2_Stein_Array_t* stein_arrays;  /* Workspaces per thread for useStein.*/
+    int     error;              /* first error, if non-zero.                    */
+    plasma_complex64_t  *pVal;  /* where to store eigenvalues.                  */
+    int     *pMul;              /* where to store Multiplicity.                 */
+    plasma_complex64_t  *pVec;  /* where to store eigenvectors.                 */
+} zlaebz2_WorkStack_t;
+
+#endif /* PLASMA_ZLAEBZ2_H */

--- a/test/test.c
+++ b/test/test.c
@@ -248,6 +248,11 @@ struct routines_t routines[] =
     { "cpotrs", test_cpotrs },
     { "spotrs", test_spotrs },
 
+    { "", NULL },
+    { "dstevx2", test_dstevx2 },
+    { "", NULL },
+    { "sstevx2", test_sstevx2 },
+
     { "zsymm", test_zsymm },
     { "dsymm", test_dsymm },
     { "csymm", test_csymm },

--- a/test/test_z.h
+++ b/test/test_z.h
@@ -59,6 +59,7 @@ void test_zpotrf(param_value_t param[], bool run);
 void test_zpotri(param_value_t param[], bool run);
 void test_zpotrs(param_value_t param[], bool run);
 void test_zsymm(param_value_t param[], bool run);
+void test_zstevx2(param_value_t param[], bool run);
 void test_zsyr2k(param_value_t param[], bool run);
 void test_zsyrk(param_value_t param[], bool run);
 void test_ztradd(param_value_t param[], bool run);

--- a/test/test_zstevx2.c
+++ b/test/test_zstevx2.c
@@ -1,0 +1,356 @@
+/**
+ *
+ * @file
+ *
+ *  PLASMA is a software package provided by:
+ *  University of Tennessee, US,
+ *  University of Manchester, UK.
+ *
+ * @precisions normal z -> s d 
+ *
+ **/
+#include "test.h"
+#include "flops.h"
+#include "plasma.h"
+#include "core_lapack.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <float.h>
+
+#include <omp.h>
+
+#define COMPLEX
+
+/******************************************************************************
+ * Matrix detailed in Kahan; et al. 
+ * Matrix Test: diag=[+x,-x,+x,-x,...+x,-x] for any real x, but Kahan chooses
+ *                                          a tiny x.
+ *              offd=[1,1,...1]
+ * Dimension: n. 
+ * Computed eigenvalues:
+ * evalue[k] = [ x*x + 4*cos(k/(n+1))^2 ] ^(1/2), 
+ * evalue[n+1-k] = -evalue[k], for k=1,[n/2],
+ * evalue[(n+1)/2] = 0 if n is odd.
+ * Note k is 1-relative in these formulations.
+ * The eigenvalues range from (-2,+2).
+ * Note: This routine verified to match documentation for n=4,8,12,24.
+ * Note: This code is a template, it is not intended to work in complex
+ *       arithmetic, it is only to be translated to either single or double.
+ *****************************************************************************/
+
+static void testMatrix_Kahan(plasma_complex64_t* diag, plasma_complex64_t *offd, 
+            plasma_complex64_t* evalue, lapack_int n, plasma_complex64_t myDiag) {
+   lapack_int i,k;
+   for (k=1; k<=(n/2); k++) {
+      plasma_complex64_t ev;
+      ev = (M_PI*k+0.)/(n+1.0); /* angle in radians.                       */
+      ev = cos(ev);             /* cos(angle)                              */
+      ev *= 4.*ev;              /* 4*cos^2(angle)                          */
+      ev += myDiag*myDiag;      /* x^2 + 4*cos^2(angle)                    */ 
+      ev = sqrt(ev);            /* (x^2 + 4*cos^2(angle))^(0.5)            */
+      /* we reverse the -ev and ev here, to get in ascending sorted order. */
+      evalue[k-1] = -ev;
+      evalue[n+1-k-1] = ev;
+   }
+
+   for (i=0; i<n-1; i++) {
+      k=(i&1);
+      if (k) diag[i]=-myDiag;
+      else   diag[i]=myDiag;
+      offd[i] = 1.0;
+   }
+
+      k=(i&1);
+      if (k) diag[i]=-myDiag;
+      else   diag[i]=myDiag;
+} /* end testMatrix_Kahan. */
+
+
+/******************************************************************************
+ * This tests an eigenvector X for the eigenvalue lambda.
+ * We should have A*X = lambda*X. Thus, (A*X)/lambda = X. 
+ * We perform the matrix multiply for each element X[i], and divide the result
+ * by lambda, yielding mmRes[i] which should equal X[i]. We sum the squares of
+ * these results, and the squares of X[i], to compute the Frobenious Norm. We
+ * return the absolute difference of these norms as the error in the vector.
+ *
+ * Matrix multiply; A * X = Y.
+ * A = [diag[0], offd[0], 
+ *     [offd[0], diag[1], offd[1]
+ *     [      0, offd[1], diag[2], offd[2],
+ *     ...
+ *     [ 0...0                     offd[n-2], diag[n-1] ]
+ *****************************************************************************/
+
+static double testEVec(plasma_complex64_t *diag, plasma_complex64_t *offd, 
+              int n, plasma_complex64_t *X, plasma_complex64_t lambda) {
+    int i;
+    double mmRes, vmRes, error, sumMM=0., sumVec=0., invLambda = 1.0/lambda;
+
+    mmRes = (diag[0]*X[0] + offd[0]*X[1])*invLambda;
+    vmRes = X[0];
+    sumMM += mmRes*mmRes;
+    sumVec += vmRes*vmRes; 
+
+    mmRes = (offd[n-2]*X[n-2] + diag[n-1]*X[n-1])*invLambda;
+    vmRes = X[n-1];
+    sumMM += mmRes*mmRes;
+    sumVec += vmRes*vmRes; 
+ 
+    for (i=1; i<(n-1); i++) {
+        mmRes = (offd[i-1]*X[i-1] + diag[i]*X[i] + offd[i]*X[i+1])*invLambda;
+        vmRes = X[i];
+        sumMM += mmRes*mmRes;
+        sumVec += vmRes*vmRes; 
+    }
+
+    sumMM = sqrt(sumMM);
+    sumVec = sqrt(sumVec);
+
+    return(fabs(sumVec-sumMM));
+} /* END TestEVec. */
+
+
+/***************************************************************************//**
+ * @brief Tests ZSTEVX2.
+ *
+ * @param[in,out] param - array of parameters
+ * @param[in]     run - whether to run test
+ *
+ * Sets used flags in param indicating parameters that are used.
+ * If run is true, also runs test and stores output parameters.
+ ******************************************************************************/
+void test_zstevx2(param_value_t param[], bool run)
+{
+    int i,j;
+    /*****************************************************************
+     * Mark which parameters are used.
+     ****************************************************************/
+    param[PARAM_DIM    ].used = PARAM_USE_M;
+    if (! run)
+        return;
+
+    /*****************************************************************
+     * Set parameters.
+     ****************************************************************/
+    int m = param[PARAM_DIM].dim.m;
+    int test = param[PARAM_TEST].c == 'y';
+    double eps = LAPACKE_dlamch('E');
+
+    /*****************************************************************
+     * Set tuning parameters.
+     ****************************************************************/
+    plasma_set(PlasmaTuning, PlasmaDisabled);
+
+    /*****************************************************************
+     * Allocate and initialize arrays.
+     ****************************************************************/
+    plasma_complex64_t *Diag =
+        (plasma_complex64_t*)malloc((size_t)m*sizeof(plasma_complex64_t));
+    assert(Diag != NULL);
+
+    plasma_complex64_t *Offd =
+        (plasma_complex64_t*)malloc((size_t)(m-1)*sizeof(plasma_complex64_t));
+    assert(Offd != NULL);
+
+    plasma_complex64_t *eigenvalues =
+        (plasma_complex64_t*)malloc((size_t)m*sizeof(plasma_complex64_t));
+    assert(eigenvalues != NULL);
+
+    plasma_complex64_t *pVal = 
+        (plasma_complex64_t*)malloc((size_t)m*sizeof(plasma_complex64_t));
+    assert(pVal != NULL);
+
+    int *pMul = (int*)malloc((size_t)m*sizeof(int));
+    assert(pMul != NULL);
+
+    /**************************************************************************
+     * Kahan has eigenvalues from [-2.0 to +2.0]. However, eigenvalues are 
+     * dense near -2.0 and +2.0, so for large matrices, the density may cause
+     * eigenvalues separated by less than machine precision, which causes us
+     * multiplicity (eigenvalues are identical at machine precision). We first
+     * see this in single precision at m=14734, with a multiplicity of 2. 
+     *************************************************************************/
+
+    plasma_complex64_t myDiag=1.e-5;
+    testMatrix_Kahan(Diag, Offd, eigenvalues, m, myDiag);
+    double minAbsEV=DBL_MAX, maxAbsEV=0., Kond;
+    for (i=0; i<m; i++) {
+        if (fabs(eigenvalues[i]) < minAbsEV) minAbsEV=fabs(eigenvalues[i]);
+        if (fabs(eigenvalues[i]) > maxAbsEV) maxAbsEV=fabs(eigenvalues[i]);
+    }
+    Kond = maxAbsEV / minAbsEV;
+    if (0) fprintf(stderr, "%s:%i min/max EV=%.16e, %.16e, Kond=%.6f\n", 
+           __func__, __LINE__, minAbsEV, maxAbsEV, Kond);
+
+    lapack_int nEigVals=0, vectorsFound=0;
+    lapack_int il=0, iu=500;
+    plasma_complex64_t vl=1.5, vu=2.01;
+    plasma_complex64_t *pVec = NULL;
+
+    /**************************************************************************
+     * Get the number of eigenvalues in a value range. Note these can include 
+     * multiplicity; the number of unique eigenvectors will be discovered by 
+     * plasma_dstevx2.
+     *************************************************************************/
+
+    lapack_int ret;
+    ret=plasma_zstevx2(
+            PlasmaCount,    /* Type of call (1)         */
+            PlasmaRangeV,   /* Range type (2)           */
+            m, 0,           /* N, k (3,4)               */
+            Diag, Offd,     /* diag, offd (5,6)         */
+            vl, vu,         /* vl, vu (7,8)             */
+            il, iu,         /* il, iu (9,10)            */
+            &nEigVals,      /* pFound, (11)             */
+            pVal,           /* p eigenvals array. (12)  */
+            pMul,           /* p eigenMult array  (13)  */
+            pVec);          /* p eigenVec  array  (14)  */
+    if (0) fprintf(stderr, "%s:%i plasmaCount for _stevx2 ret=%i, nEigVals=%d.\n", __func__, __LINE__, ret, nEigVals);
+    
+    if (nEigVals < 1) {
+       if (0) fprintf(stderr, "%s:%i Invalid nEigVal=%d.\n", __func__, __LINE__, nEigVals);
+       assert(nEigVals > 0);
+    }
+
+    /**************************************************************************
+     * We allocate pVec late, we cannot afford to allocate m*m entries
+     * (to cover every possibility) when m is huge. 
+     *************************************************************************/
+
+    pVec = (plasma_complex64_t*)malloc((size_t)m*nEigVals*sizeof(plasma_complex64_t));
+    assert(pVec != NULL);
+
+    /* Run and time plasma_dstevx2, range based on values. */
+    plasma_time_t start = omp_get_wtime();
+
+    ret=plasma_zstevx2(
+            PlasmaVec,     /* Type of call (1)          */
+            PlasmaRangeV,  /* Range type (2)            */
+            m, nEigVals,   /* N, k (3,4)                */
+            Diag, Offd,    /* diag, offd (5,6)          */
+            vl, vu,        /* vl, vu (7,8)              */
+            il, iu,        /* il, iu (9,10)             */
+            &vectorsFound, /* pFound, (11)              */
+            pVal,          /* p eigenvals array. (12)   */
+            pMul,          /* p eigenMult array  (13)   */
+            pVec);         /* p eigenVec  array  (14)   */
+
+    plasma_time_t stop = omp_get_wtime();
+    plasma_time_t time = stop-start;
+
+    param[PARAM_TIME].d = time;
+
+    /*****************************************************************
+     * Test results directly. Check eigenvalues discovered by vl, vu.
+     ****************************************************************/
+
+    if (test) {
+        if (0) fprintf(stderr, "%s:%i plasmaRangeV for _stevx2 m=%i ret=%i, time=%.6f, vectorsFound=%i.\n", __func__, __LINE__, m, ret, time, vectorsFound);
+
+        if (0) fprintf(stderr, "%s:%i first pVal=%.15f (mpcty=%i), last=%.15f (mpcty=%i).\n", __func__, __LINE__, pVal[0], pMul[0], pVal[vectorsFound-1], pMul[vectorsFound-1]);
+        if (0) fprintf(stderr, "%s:%i eigenvalues[m-1=%i] %.15f.\n", __func__, __LINE__, m-1, eigenvalues[m-1]);
+
+        /**********************************************************************
+         * Find worst eigenvalue error. However, we must worry about
+         * multiplicity. In single precision this first occurs at m=14734, with
+         * vl=1.5, vu=2.01; mpcity=2. At m=75000, vl=1.5, vu=2.01, mpcity=10.
+         * We must also worry about the magnitude of eigenvalues; machine 
+         * epsilon for large eigenvalues is much greater than for small ones.
+         *********************************************************************/
+
+        plasma_complex64_t worstEigenvalue_error = 0, worstEigenvalue_eps;
+        lapack_int worstEigenvalue_index = 0, worstEigenvalue_mpcty = 0, max_mpcty = 0;
+        plasma_complex64_t worstEigenvector_error = 0;
+        lapack_int worstEigenvector_index = 0;
+        i=0;
+        lapack_int evIdx=m-nEigVals;
+        while (evIdx < m) {
+            if (pMul[i] > max_mpcty) max_mpcty = pMul[i];
+
+            for (j=0; j<pMul[i]; j++) {
+                double ev_eps = nexttoward(fabs(eigenvalues[evIdx]), DBL_MAX) - fabs(eigenvalues[evIdx]);
+                plasma_complex64_t error = fabs(pVal[i]-eigenvalues[evIdx]) / ev_eps;
+                if (error > worstEigenvalue_error) {
+                    worstEigenvalue_index = i;
+                    worstEigenvalue_error = error;
+                    worstEigenvalue_eps = ev_eps; 
+                    worstEigenvalue_mpcty = pMul[i];
+                }
+
+                evIdx++; /* advance known eigenvalue index for a multiplicity. */
+                if (evIdx == m) break;
+            }
+           
+            i++; /* advance to next discovered eigenvalue. */         
+        }
+
+        if (0)  fprintf(stderr, "%s:%i worst eigenvalue error: index %i, "
+                "error %.3f in ev_eps =(%.6e) |computed-analytic|=%.15f. "
+                "Max Mpcty=%i.\n", 
+                __func__, __LINE__, 
+                worstEigenvalue_index, worstEigenvalue_error, 
+                worstEigenvalue_eps, 
+                fabs(pVal[worstEigenvalue_index] - eigenvalues[worstEigenvalue_index]), 
+                max_mpcty);
+
+        param[PARAM_ERROR].d = worstEigenvalue_error*worstEigenvalue_eps;
+        param[PARAM_SUCCESS].i = (worstEigenvalue_error < 3.);
+
+        if (!param[PARAM_SUCCESS].i) goto TestingDone; /* exit if not successful. */
+
+        /**********************************************************************
+         * If we have no eigenvalue errors, We need to test the eigenvectors in
+         * pVec; testEVec returns fabs(||(A*pVec)/pVal||_2 - ||pVec||_2) for
+         * each eigenvalue and eigenvector, we track the largest value.
+         * Empirically; the error grows slowly with m. We divide by epsilon,
+         * and 2*ceil(log_2(m)) epsilons seems a reasonable threshold without
+         * being too liberal. Obviously this is related to the number of bits
+         * of error in the result. The condition number (Kond) of the Kahan
+         * matrix also grows nearly linearly with m; Kond is computed above.
+         *********************************************************************/ 
+
+        for (i=0; i<vectorsFound; i++) {
+            double vErr;
+            vErr=testEVec(Diag, Offd, m, &pVec[m*i], pVal[i]);
+
+            if (vErr > worstEigenvector_error) {
+                if (0) fprintf(stderr, "%s:%i new WorstEigenvector_error "
+                       "%.16e (%.1f eps), eval=%.16e index=%i.\n",
+                       __func__, __LINE__, vErr, 
+                       (vErr/eps),pVal[i], i);
+                worstEigenvector_error = vErr; 
+                worstEigenvector_index = i;
+            }
+        }
+
+        /* Find ceiling(log_2(m)); double it as allowable eps of err */
+        i=1;
+        while ((m>>i)) i++;
+        if (0) fprintf(stderr, "%s:%i 2*ceiling(log_2(%i))=%i, vErr=%.3f eps.\n", 
+               __func__, __LINE__, m, i<<1, (worstEigenvector_error/eps));
+
+        param[PARAM_ERROR].d = (worstEigenvector_error);
+        param[PARAM_SUCCESS].i = (worstEigenvector_error <= (i<<1)*eps);
+    } /* end if (test) */
+
+    /*****************************************************************
+     * Free arrays.
+     ****************************************************************/
+TestingDone: 
+    if (Diag != NULL) free(Diag);
+    if (Offd != NULL) free(Offd);
+    if (eigenvalues != NULL) free(eigenvalues);
+    if (pVal != NULL) free(pVal);
+    if (pMul != NULL) free(pMul);
+    if (pVec != NULL) free(pVec);
+
+    if (test) {
+        /* free test matrices; currently none. */
+    }  
+} /* end test_zstevx2 */

--- a/tools/generate_precisions.py
+++ b/tools/generate_precisions.py
@@ -12,13 +12,15 @@ def codegen(letters, filenames, fn_format):
             os.system("python tools/codegen.py -p {} {}".format(letter, fn_format.format(filename)))
 
 def main(argv):
-    codegen("s d c", "plasma_z plasma_internal_z core_lapack_z plasma_core_blas_z", "include/{}.h")
+    codegen("s d c", "plasma_z plasma_internal_z core_lapack_z plasma_core_blas_z plasma_zlaebz2_work", "include/{}.h")
     codegen("ds", "include/plasma_zc.h include/plasma_internal_zc.h include/plasma_core_blas_zc.h test/test_zc.h", "{}")
     codegen("s d c", "dzamax zgelqf zgemm zgbmm zgeqrf zgesdd zunglq zungqr zunmlq zunmqr zpotrf zpotrs zsymm zsyr2k zsyrk ztradd ztrmm ztrsm ztrtri zunglq zungqr zunmlq zunmqr zgbsv zgbtrf zgbtrs zgeadd zgeinv zgelqs zgels zgeqrs zgesv zgeswp zgetrf zgetri zgetrs zhemm zher2k zherk zhesv zhetrf zhetrs zlacpy zlangb zlange zlanhe zlansy zlantr zlascl zlaset zlauum zpbsv zpbtrf zpbtrs zpoinv zposv zpotri zgetri_aux zdesc2ge zdesc2pb zdesc2tr zge2desc zgb2desc zgbset zpb2desc ztr2desc pdzamax pzgbtrf pzgeadd pzgelqf pzgelqf_tree pzgemm pzgeqrf pzgeqrf_tree pzgeswp pzgetrf pzgetri_aux pzhemm pzher2k pzherk pzhetrf_aasen pzlacpy pzlangb pzlange pzlanhe pzlansy pzlantr pzlascl pzlaset pzlauum pzpbtrf pzpotrf pzsymm pzsyr2k pzsyrk pztbsm pztradd pztrmm pztrsm pztrtri pzunglq pzunglq_tree pzungqr pzungqr_tree pzunmlq pzunmlq_tree pzunmqr pzunmqr_tree pzdesc2ge pzdesc2pb pzdesc2tr pzge2desc pzgb2desc pzpb2desc pztr2desc pzge2gb pzgbbrd_static pzgecpy_tile2lapack_band pzlarft_blgtrd pzunmqr_blgtrd", "compute/{}.c")
+    codegen("s d", "zlaebz2 zlaneg2 zstevx2", "compute/{}.c")
     codegen("ds", "zcposv zcgesv zcgbsv clag2z zlag2c pclag2z pzlag2c", "compute/{}.c")
     codegen("s d c", "zgeadd zgemm zgeswp zgetrf zheswp zlacpy zlacpy_band zheswp ztrsm dzamax zgelqt zgeqrt zgessq zhegst zhemm zher2k zherk zhessq zlange zlanhe zlansy zlantr zlascl zlaset zlauum zunmlq zunmqr zpemv zpamm zpotrf zhegst zsymm zsyr2k zsyrk zsyssq ztradd ztrmm ztrssq ztrtri ztslqt ztsmlq ztsmqr ztsqrt zttlqt zttmlq zttmqr zttqrt zunmlq zunmqr zparfb dcabs1 zlarfb_gemm zgbtype1cb zgbtype2cb zgbtype3cb", "core_blas/core_{}.c")
     codegen("ds", "zlag2c clag2z", "core_blas/core_{}.c")
     codegen("s d c", "z.h", "test/test_{}")
+    codegen("s d", "zstevx2.c", "test/test_{}")
     codegen("s d c", "dzamax zgbsv zgbtrf zgeadd zgeinv zgelqf zgelqs zgels zgemm zgbmm zgeqrf zgeqrs zgesv zgeswp zgetrf zgetri_aux zgetri zgetrs zhemm zher2k zherk zhesv zhetrf zlacpy zlangb zlange zlanhe zlansy zlantr zlascl zlaset zlauum zpbsv zpbtrf zpoinv zposv zpotrf zpotri zpotrs zsymm zsyr2k zsyrk ztradd ztrmm ztrsm ztrtri zunmlq zunmqr zgesdd", "test/test_{}.c")
     codegen("ds", "zcposv zcgesv zcgbsv zlag2c clag2z", "test/test_{}.c")
     return 0

--- a/tools/subs.py
+++ b/tools/subs.py
@@ -202,6 +202,7 @@ lapack = [
     ('sgeqp3',               'dgeqp3',               'cgeqp3',               'zgeqp3'              ),
     ('sgeqr2',               'dgeqr2',               'cgeqr2',               'zgeqr2'              ),
     ('sgeqrf',               'dgeqrf',               'cgeqrf',               'zgeqrf'              ),
+    ('sorgqr',               'dorgqr',               'corqqr',               'zorgqr'              ),
     ('sgeqrs',               'dgeqrs',               'cgeqrs',               'zgeqrs'              ),
     ('sgeqrt',               'dgeqrt',               'cgeqrt',               'zgeqrt'              ),
     ('sgerfs',               'dgerfs',               'cgerfs',               'zgerfs'              ),
@@ -230,6 +231,7 @@ lapack = [
     ('slacpy',               'dlacpy',               'clacpy',               'zlacpy'              ),
     ('slacrm',               'dlacrm',               'clacrm',               'zlacrm'              ),
     ('sladiv',               'dladiv',               'cladiv',               'zladiv'              ),
+    ('slaebz2',              'dlaebz2',              'claebz2',              'zlaebz2'             ), # No complex, z is just a template.
     ('slaed',                'dlaed',                'slaed',                'dlaed'               ),
     ('slaex',                'dlaex',                'slaex',                'dlaex'               ),
     ('slag2d',               'dlag2s',               'clag2z',               'zlag2c'              ),
@@ -240,6 +242,7 @@ lapack = [
     ('slamc3',               'dlamc3',               'slamc3',               'dlamc3'              ),
     ('slamch',               'dlamch',               'slamch',               'dlamch'              ),
     ('slamrg',               'dlamrg',               'slamrg',               'dlamrg'              ),
+    ('slaneg',               'dlaneg',               'claneg',               'zlaneg'              ),
     ('slange',               'dlange',               'clange',               'zlange'              ),
     ('slange',               'dlange',               'slange',               'dlange'              ),
     ('slangb',               'dlangb',               'clangb',               'zlangb'              ),
@@ -315,6 +318,7 @@ lapack = [
     ('ssteqr',               'dsteqr',               'csteqr',               'zsteqr'              ),
     ('ssterf',               'dsterf',               'ssterf',               'dsterf'              ),
     ('ssterm',               'dsterm',               'csterm',               'zsterm'              ),
+    ('sstevx2',              'dstevx2',              'cstevx2',              'zstevx2'             ), # No complex; z is just a template.
     ('sstt21',               'dstt21',               'cstt21',               'zstt21'              ),
     ('ssycpy',               'dsycpy',               'checpy',               'zhecpy'              ),
     ('ssyev',                'dsyev',                'cheev',                'zheev'               ),


### PR DESCRIPTION
This pull requests adds five new files. 1) laneg2 is most similar
to LAPACK laneg, but uses Zhang's scaled Sturm sequence which we
found empirically superior on troublesome matrices. It does a
single bisection.  2) laebz2 uses laneg2 to perform the parallel
work of finding eigenvalues (and optionally eigenvectors) in a
range, of either values or indexes.  Unlike LAPACK laebz, we
handle multiplicity; theoretically this is not necessary on ST
matrices, but on large matrices eigenvalue density can produce
multiple eigenvalues within machine precision of each other, and
the result is multiplicity. laebz2 uses an array of structures
defined in 3) include/plasma_zlaebz2_work. 4) stevx2 is the
show-runner, unlike LAPACK stevx, this includes swapping pairs of
eigenvectors if they perform better, and uses plasma_geqrf to
orthogonalize eigenvectors.  This is a necessary step because
inverse iteration does not guarantee orthogonality, especially
when eigenvalues are close, either absolutely (their difference
is tiny) or relatively (their ratio is very close to 1). 5)
test/test_zstevx2.c is the tester for this code; it uses a Kahan
matrix of size "M" that has directly computable eigenvalues we
can use to verify that we are finding the correct eigenvalues,
and we test the eigenvectors by testing them (without using any
additional memory allocations).  Note that the 'z' precision
files are only a code template, the only code generated is for
single and double precision real (sstevx2, dstevx2). Other files
are changed to incorporate these files into the build system.