### PR TITLE
Fix issue with installing w/out Fortran interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,9 @@ install_dirs:
 
 install: lib install_dirs
 	cp include/*.h $(prefix)/include
+ifeq ($(fortran), 1)
 	cp include/*.mod $(prefix)/include
+endif
 	cp $(libfiles) $(prefix)/lib
 	# pkgconfig
 	cat lib/pkgconfig/plasma.pc.in         | \


### PR DESCRIPTION
Currently, `make install` fails when the Fortran interface is disabled because it always tries to copy the `*.mod` files into the install directory, even when they don't exist.

This PR makes the problematic copy conditional on the fortran interface being built.