### PR TITLE
Fix bug in PLASMA GBMM tester

### DIFF
--- a/compute/zgbset.c
+++ b/compute/zgbset.c
@@ -79,9 +79,11 @@ void plasma_zgbset(int m, int n, int kl, int ku,
         }
     }
     // wide rectangular matrix
-    else if(n>m)
+    else /* if(n>m) */
     {
-        // clear out a square part of the matrix (left side).
+        // clear out the square part of the matrix (left side).
+        // so we will use all 'm's instead of 'm's and 'n's. We 
+        // will clear out the right side later.
         int cornerI, cornerJ, extralower, extraupper;
         if(kl+ku < m)
         {
@@ -92,7 +94,7 @@ void plasma_zgbset(int m, int n, int kl, int ku,
         else
         {
             extralower = m-1-kl;
-            extraupper = n-1-ku;
+            extraupper = m-1-ku;
         }
         for(; extralower > 0; extralower--)
         {
@@ -101,12 +103,14 @@ void plasma_zgbset(int m, int n, int kl, int ku,
         }
         for(; extraupper > 0; extraupper--)
         {
-            cornerJ = n-extraupper;
+            cornerJ = m-extraupper;
             plasma_zlaset(PlasmaGeneral,1,extraupper,0,0,pA+lda*cornerJ,lda+1);
         }
         // now zero out the right side
+        // i: the row that we are zeroing
         for(int i = 0; i < m; i++)
         {
+            // blcols: the number of columns in the row that belong to the band
             int blcols = (i-(m-1)+ku) > 0 ? (i-(m-1)+ku) : 0;
             if (n-(m+blcols) <= 0)
             {

--- a/test/test_zgbmm.c
+++ b/test/test_zgbmm.c
@@ -9,7 +9,6 @@
  * @precisions normal z -> s d c
  *
  **/
- /* Implemented by Daniel Mishler beginning on 07-12-12, 11:05 */
 #include "test.h"
 #include "flops.h"
 #include "plasma.h"


### PR DESCRIPTION
Piotr (and all concerned),

If you were to make PLASMA right now and run the following tests, you would notice that some of them fail!

```
./plasmatest dgbmm --dim=0500x0700x0600 --ku=001 --kl=001                       
./plasmatest dgbmm --dim=1500x1700x1600 --ku=001 --kl=700 # fails               
./plasmatest dgbmm --dim=0500x0600x0700 --ku=102 --kl=102                       
./plasmatest dgbmm --dim=0500x0700x0600 --ku=102 --kl=102                       
./plasmatest dgbmm --dim=0600x0500x0700 --ku=102 --kl=102 # fails               
./plasmatest dgbmm --dim=0600x0700x0500 --ku=102 --kl=102                       
./plasmatest dgbmm --dim=0700x0500x0600 --ku=102 --kl=102                       
./plasmatest dgbmm --dim=0700x0600x0500 --ku=102 --kl=102                       
./plasmatest dgbmm --dim=1500x1700x1600 --ku=122 --kl=132 # fails               
./plasmatest dgbmm --dim=1000x1000x1001 --ku=100 --kl=100 # fails  
```

Why? It's not because of the GBMM work code (which is in the `compute/zgemm.c` and `compute/pzgemm.c` files). It's because the tester generates a bad band matrix that the code then assumes was made correctly, and then skips out on multiplying elements that the tester's reference GEMM will not skip.


This tester bug specifically affects some matrix multiplications where the band matrix (`A`) is wider than it is tall.

You'll notice that the failing cases are when the matrix is called specifically with `k>m`. This is because the case for setting up wide rectangular band matrices is inconsistent. In particular, it may have neglected to zero matrix elements around row `0`, column `m`. Not all such cases with `k>m` fail, however (the first and third test cases are examples). Why sometimes such an error makes it past the tester is something I currently don't know.

With this fix, all of the test listed above will pass.


When I look at the code as a whole, I hope there exists a simpler way to prepare rectangular band matrices. For now I want to at least fix this bug.



I also clarified the purposes a couple variables for readability, and removed my name from the plasma gbmm tester to make it consistent with the other files in the `test/` directory