### PR TITLE
fix CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/compute/scamax.c")
 else ()
   message( STATUS "Missing files some precision files, trying to generate" )
 
+  include(CheckSymbolExists)
   include( FindPython )  # requires CMake 3.12
 
   if (Python_FOUND)


### PR DESCRIPTION
When I compile plasma, some error occur. Maybe `CheckSymbolExists` needs to be manually included.
```shell
-- Building for: Visual Studio 17 2022
-- Selecting Windows SDK version 10.0.22000.0 to target Windows 10.0.22631.
-- The C compiler identification is MSVC 19.34.31937.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: E:/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for sgemm_
-- Looking for sgemm_ - not found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- Looking for sgemm_
-- Looking for sgemm_ - found
-- Found BLAS: D:/intel/oneAPI/mkl/latest/lib/mkl_intel_lp64_dll.lib;D:/intel/oneAPI/compiler/latest/lib/libiomp5md.lib;D:/intel/oneAPI/mkl/latest/lib/mkl_intel_thread_dll.lib;D:/intel/oneAPI/mkl/latest/lib/mkl_core_dll.lib
-- Looking for cheev_
-- Looking for cheev_ - found
-- Found LAPACK: D:/intel/oneAPI/mkl/latest/lib/mkl_intel_lp64_dll.lib;D:/intel/oneAPI/compiler/latest/lib/libiomp5md.lib;D:/intel/oneAPI/mkl/latest/lib/mkl_intel_thread_dll.lib;D:/intel/oneAPI/mkl/latest/lib/mkl_core_dll.lib
-- BLAS(TRUE)
-- LAPACK(TRUE)
-- Found Intel MKL
CMake Error at Modules/FindMKL.cmake:36 (check_symbol_exists):
  Unknown CMake command "check_symbol_exists".
Call Stack (most recent call first):
  Modules/FindCBLAS.cmake:34 (find_package)
  CMakeLists.txt:72 (find_package)
```