### PR TITLE
more consistent space in headers

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,1316 @@
+[TOC]
+
+About this guide
+================
+
+This guide is mostly based on the
+[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
+
+> Sometimes the Google rules are tweaked, sometimes contradicted.
+>
+> This guide includes rules beyond those in the Google guide.
+
+Other notable sources of best software engineering practices include:
+
+* [JSF Air Vehicle C++ Coding Standards](http://www.stroustrup.com/JSF-AV-rules.pdf),
+* [Code Complete](http://cc2e.com) by Steve McConnell,
+* [Source codes of the Trilinos project](https://trilinos.org),
+* [Microsoft .Net Guidelines](https://msdn.microsoft.com/en-us/library/ms229042(v=vs.110).aspx),
+* [Linux Kernel Coding Style](https://www.kernel.org/doc/Documentation/CodingStyle).
+
+Some conventions introduced in this guide originate from:
+
+* NVIDIA CUDA,
+* Intel MKL,
+* Microsoft.
+
+This guide is created using Markdown.
+For Markdown documentation consult:
+
+* http://daringfireball.net/projects/markdown/,
+* https://en.wikipedia.org/wiki/Markdown,
+
+General Guidelines
+==================
+
+* Be consistent in your own code.
+* Follow the conventions already established by the project.
+* If you spot inconsistencies, fix them.
+* Break rules if it helps readability. This is only a guide.
+
+> Established ICL projects (PLASMA, MAGMA, PaRSEC, PAPI) already have their
+> conventions. In most cases, existing project conventions override conventions
+> in this guide. Unless, you can fix bad practices in an existing project by consistently
+> applying a better convention across the entire source code, a task which can sometimes
+> be automated.
+>
+> Definitely follow this guide if starting a new project or a prototype.
+
+Standard Compliance
+===================
+
+C codes should be C99 compliant and compiled with the `-std=c99` flag,
+and C++ codes should be C++11 compliant and compiled with the `-std=c++11` flag.
+
+Avoid features present only in C but not in C++. That is, C code should compile with either C or C++ compiler.
+
+> Microsoft's C compiler doesn't support C99, so code must use C++11.
+
+Header Files
+============
+
+Self-contained Headers
+----------------------
+
+Header files should be self-contained and end in `.h` for C and in `.hh` for C++.
+Files that are meant for textual inclusion, but are not headers, should end in `.inc`.
+
+> Google uses `.cc` for C++ source files, but `.h` for C++ header files.
+> However, it is useful to have a distinction between C and C++ headers.
+> Therefore, we use `.c` and `.h` for C and `.cc` and `.hh` for C++.
+>
+> Trilinos uses another common convention of `.cpp` and `.hpp`.
+> However, in a long list of files, this puts a lot of <p>s on the screen.
+> The `.cc` and `.hh` endings are shorter and cleaner.
+
+\#define Guards
+--------------
+
+All header files should have `#define` guards to prevent multiple inclusion.
+The format of the symbol name should be `<ICL>_<PROJECT>_<FILE>_H` for C
+and `<ICL>_<PROJECT>_<FILE>_HH` for C++.
+
+```
+#!cpp
+
+#ifndef ICL_MAGMA_BLAS_H
+#define ICL_MAGMA_BLAS_H
+
+...
+
+#endif // ICL_MAGMA_BLAS_H
+```
+
+> Google uses an underscore at the end.
+> Some projects use an underscore at the beginning and an underscore at the end.
+> Trilinos does not use underscores.
+> In the case of header guards, beginning/ending underscores seem pointless.
+> Underscores in front of a name are used for system-level hacking.
+
+extern C
+--------
+
+C library headers should add extern "C" around function definitions, to allow C++ codes to use the library.
+
+```
+#!cpp
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+...
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+```
+
+Forward Declarations
+--------------------
+
+Avoid using forward declarations, i.e., declarations of classes, functions,
+or templates without associated definitions.
+Instead, `#include` the headers you need. This limits the number of places that
+have to be modified if the members change.
+Check [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Forward_Declarations)
+to see why.
+
+Inline Functions
+----------------
+
+Mark small functions as inline, specifically those that serve as macro replacements.
+Although the compiler will identify on its own functions
+suitable for inlining, it is a good idea hint it directly.
+Define as inline member accessors and functions that would otherwise be macros,
+e.g., address arithmetic functions and alike.
+Check [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Inline_Functions)
+for further guidelines.
+
+Names and Order of Included Header Files
+----------------------------------------
+
+Use the following order of inclusion:
+
+* your project headers,
+* standard headers,
+* other libraries' headers.
+
+For example, the include section might look like this:
+
+```
+#!cpp
+
+#include "common_magma.h"
+#include "batched_kernel_param.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include <omp.h>
+#include <cuda.h>
+#include <mkl_blas.h>
+```
+
+> This ordering is a little different from the one in the
+> [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes).
+
+All of project's header files should be listed as descendants of the project's
+source directory without use of UNIX directory shortcuts `.` (the current directory)
+or `..` (the parent directory).
+
+You should include all the headers that define the symbols you rely upon.
+If you rely on symbols from `bar.h`, do not count on the fact that you included `foo.h`
+which (currently) includes `bar.h`.
+Include `bar.h` explicitly.
+However, any includes present in the related header do not need to be included again
+in the related `.cc` (i.e., `foo.cc` can rely on `foo.h`'s includes).
+
+Sometimes, system-specific code needs conditional includes.
+Such code can put conditional includes after other includes.
+Keep your system-specific code small and localized.
+
+```
+#!cpp
+
+#ifndef __APPLE__
+#include <pthread.h>
+#else
+#include <libkern/OSAtomic.h>
+
+...
+
+#endif // __APPLE__
+```
+
+Scoping
+=======
+
+Namespaces
+----------
+
+With few exceptions, place code in a namespace.
+Use named namespaces as follows:
+
+* Namespaces wrap the entire source file after includes.
+* Do not declare anything in namespace std, including forward declarations
+  of standard library classes. Declaring entities in namespace std is undefined
+  behavior. To declare entities from the standard library, include the appropriate
+  header file.
+* Do not use a `using` directive to make all names from a namespace available.
+* Do not use `using` declarations in `.hh` files, because anything imported
+  into a namespace in a `.hh` file becomes part of the public API exported by that file.
+* Use a `using` declaration anywhere in a `.cc` file (including in the global namespace),
+  and in functions, methods, and classes.
+* Minimize the use of namespace aliases.
+* Do not use inline namespaces.
+* Use Pascal case for namespace components.
+
+Namespaces should have unique names based on the project name.
+Generic components, that may be shared among multiple projects, such as, e.g.,
+an efficient implementation of a thread-safe hash table, may be placed in
+a namespace `Icl`, while project-specific components may be placed
+in a namespace, e.g., `Icl::Magma`.
+
+Format namespaces in `.hh` files as follows:
+
+```
+#!cpp
+
+#ifndef ICL_MAGMA_HH
+#define ICL_MAGMA_HH
+
+#include <cuda.h>
+
+namespace Icl {
+namespace Magma {
+
+...
+
+} // namespace Magma
+} // namespace Icl
+
+#endif // ICL_MAGMA_HH
+```
+
+Nonmember, Static Member, and Global Functions
+----------------------------------------------
+
+Prefer placing nonmember functions in a namespace; use completely global functions rarely.
+Prefer grouping functions with a namespace instead of using a class as if it was a namespace.
+
+Sometimes it is useful to define a function not bound to a class instance.
+Such a function can be either a static member or a nonmember function.
+Nonmember functions should not depend on external variables,
+and should nearly always exist in a namespace.
+Rather than creating classes only to group static member functions
+which do not share static data, use namespaces instead.
+
+If you must define a nonmember function and it is only needed in its `.cc` file,
+use an unnamed namespace or static linkage (e.g., `static int Foo() {...}`)
+to limit its scope.
+
+Local Variables
+---------------
+
+Place local variables in the narrowest scope possible.
+Declare loop counters inside the `for` and `while` statements if possible.
+
+Initialize variables that are initialized once in the declaration.
+If the variable is reused, use declaration in a separate line preceeding its first use,
+e.g.:
+
+```
+#!cpp
+
+cublasStatus_t retval;
+
+retval = cublasCreate(...);
+assert(retval == CUBLAS_STATUS_SUCCESS);
+
+retval = cublasDestroy(...);
+assert(retval == CUBLAS_STATUS_SUCCESS);
+```
+
+Static and Global Variables
+---------------------------
+
+Do not use global variables.
+Use static variables only for Plain Old Data (POD): only ints, chars, floats,
+or pointers, or arrays/structs of POD. Check the
+[Google Style Guide](https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables)
+for detailed explanations.
+
+Classes
+=======
+
+In the context of numerical software, many advanced features of C++ can,
+and should be, ignored.
+
+* Do not define implicit conversions.
+
+* Do not use delegating and inheriting constructors. Use helper functions instead.
+
+* Use a `struct` only for passive objects that carry data; everything else is a class.
+> Note that member variables in structs and classes have different naming rules.
+
+* Use composition instead of inheritance.
+  Encapsulate rather than derive.
+  If you end up using inheritance, try to limit `protected` to functions,
+  don’t use for data members.
+
+* Overload operators judiciously.
+  Define overloaded operators only if their meaning is obvious, unsurprising,
+  and consistent with the corresponding built-in operators.
+  Define operators only on your own types.
+> Operator overloading makes sense for numerical objects, such as complex numbers
+> or extended precision numbers.
+
+* Make data members private, unless they are `static const`.
+
+* Use private before public. Within each section, use the following order:
+    - constants,
+    - data members,
+    - constructors,
+    - destructors,
+    - methods.
+
+Copyable and Movable Types
+--------------------------
+
+In numerical libraries, we basically have two types of classes:
+small classes to represent complex numbers and extended precision numbers,
+and big classes to represent contexts and descriptors.
+Handling of the small classes is straightforward.
+They can be copyable and movable, and use overloaded operators.
+Handling of the big classes requires a little more caution, due to the issue
+of ownership of pointers.
+The issue basically boils down to the definition of a descriptor.
+
+Numerical libraries often introduce descriptors, which describe the layout
+of the data, but do not contain the actual memory references.
+Instead, memory pointers are passed alongside descriptors to library routines.
+ScaLAPACK can serve as a legacy example,
+NVIDIA cuDNN can serve as a contemporary example.
+In this case, the descriptor itself is perfectly copyable and mutable.
+
+However, at some level, this separation goes against object oriented programming
+(defies the principle encapsulation).
+PLASMA already set a precedence by including the memory pointer in the
+matrix descriptor.
+Decoupling memory references from descriptors becomes even more troublesome
+if a single descriptor describes data requiring more than one memory pointer,
+e.g., a low-rank matrix approximation represented by its SVD.
+
+Therefore, big classes, representing large mathematical objects,
+should be handled as follows:
+
+* Be self-contained, i.e., contain all memory pointers.
+
+* Set all memory pointers to NULL at the time of initialization
+  (in the constructor in C++).
+  Rely on constructors or factory methods or `Init()` methods to perform
+  allocations and initializations.
+  Free memory in destructors or `Finalize()` methods and include a check
+  for NULL.
+
+* Be non-copyable and non-movable and be passed by reference.
+
+Functions
+=========
+
+* Write short functions.
+  If possible, write functions that fit on one screen.
+  If a function exceeds about 50 lines, think about whether it can be broken up
+  without harming the structure of the program.
+
+* All parameters passed by reference must be labeled `const` unless they are
+  modified in the function.
+
+* Use function overloading judiciously.
+
+* Avoid default arguments.
+
+* Avoid trailing return type syntax.
+
+Parameter Ordering
+------------------
+
+Place all input-only parameters before any output parameters.
+In particular, do not add new parameters to the end of the function
+just because they are new; place new input-only parameters before the output parameters.
+
+Use the following ordering of parameters:
+
+* library handle/context,
+* data layout specifier,
+* input parameters,
+* output parameters,
+* flags.
+
+Place array size before the memory pointer.
+
+Other C++ Features
+==================
+
+* Use friend classes within reason.
+  A common use of friend is to have a `FooBuilder` class be a friend of `Foo`
+  so that it can construct the inner state of `Foo` correctly, without exposing
+  this state to the world.
+  In some cases it may be useful to make a unit test class a friend of the class it tests.
+
+* Avoid using Run Time Type Information.
+
+* Use traditional, C-style, casting.
+  In numerical codes virtually all casts are conversions and there is no ambiguity.
+  The syntax of C++ style casts is nasty.
+  Also, `(long long)x` is the only way to convert to the `long long` type, because
+  of the space.
+  And also, the proper name of `long` is `long int`, which also includes the space.
+
+* Do not use C++ streams.
+  Use C standard IO functions instead.
+  C++ streams are cumbersome and the
+  [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Streams)
+  provides a long list of reasons why.
+
+* Use preincrement/predecrement (`++i`) as opposed to postincrement/postdecrement (`i++`).
+  This is a common C++ convention.
+
+* Use the following notations when initializing variables:
+  `1` for integers, `1.0` for doubles, `1.0f` for floats, `0x01` for bit patterns.
+
+* Prefer `sizeof(type)` to `(sizeof varname)`.
+  It is more traditional and more explicit.
+
+* Use `auto` for long type names.
+
+* Avoid complicated template programming.
+  Use templates for handling numerical types, such as complex or extended precision.
+  Some projects, such as BEAST, use templates for specialized purposes, such as
+  parametrization of tunable codes.
+
+* Do not use Boost for codes meant for public releases, such as numerical libraries.
+  Use it for small projects.
+
+* Feel free to use C++11 features.
+
+Use of enum
+-----------
+
+Use `enum` whenever possible.
+More type safety is good.
+Wrap then in typedefs, so the word `enum` only shows up in the definition.
+
+Use of const
+------------
+
+The use of `const` is strongly encouraged in external and internal interfaces.
+
+Use `const` such that the declaration can be read from right to left.
+
+> `const` is viral: if you pass a `const` variable to a function,
+> that function must have `const` in its prototype.
+>
+> Intel MKL uses `const` for all input function parameters.
+> NVIDIA cuBLAS does not use `const` for input parameters passed by value,
+> only for input parameters passed by pointer.
+
+Use of restrict
+---------------
+
+Avoid `restrict`. Only use if there is a clear performance benefit.
+
+Exceptions
+----------
+
+You may use C++ exceptions.
+[Google Style Guide](https://google.github.io/styleguide/cppguide.html#Exceptions)
+argues against it, but Trilinos uses it.
+Pick one way or the other and stick to it.
+
+If you use exceptions, list exceptions in function comments, but not in signatures.
+Listing in signatures is a bad idea (http://www.gotw.ca/publications/mill22.htm),
+and it is deprected in C++11.
+
+Integer Types
+-------------
+
+Most of the time, use the `int` type and safely assume that it is at least 32 bits.
+Do not assume that it is more than 32 bits, though.
+If you need any other integer type than `int`, use a precise-width integer type
+from `<cstdint>`.
+Always use `size_t` to describe the size of a memory region or offset.
+
+Do not use unsigned types unless specifically required.
+In particular, do not use unsigned types to say a number will never be negative.
+Use `int64_t` for integers for which 32 bits is not enough.
+If you really need an unsigned type, use the width-specific type,
+even for a 32-bit integer. I.e., use `uint32_t` instead of `unsigned int`.
+Basically, never use the `unsigned` keyword.
+
+> The use of unsigned types for loop counters can introduce bugs and prevent
+> compiler optimizations.
+
+Do not use a larger type than `int` for a variable, just because it will be used
+in an intermediate calculation that may overflow, such as address calculation.
+Use explicit casts to `size_t` for all address arithmetic that may overflow.
+Declare variables only of the size required for the maximum value the variable
+may store. Also, do not use integer types shorter than `int` unless specifically
+required, e.g., to minimize the memory footprint of a large array.
+
+NULL, nullptr, 0
+----------------
+
+In C++ use nullptr - removes ambiguity. You can take sizeof(nullptr).
+
+64-bit Addressing
+-----------------
+
+In numerical codes, the need for using 64-bit variables to index arrays is rare,
+but the chance of the memory offset not fitting in 32 bits is high. Therefore:
+
+* Always use a cast to `size_t` when indexing large arrays involves
+  arithmetic operations.
+
+* Use a cast to `size_t` inside all memory allocation functions.
+
+```
+#!cpp
+
+array[(size_t)...
+
+malloc((size_t)...
+```
+
+> Generally, we assume the matrix dimensions can be passed as 32-bit `int`,
+> only the offset (i + j * lda) needs to be computed as 64-bit.
+> So, we can use the 32-bit LAPACK interface.
+> One place this fails is passing `lwork`, if it needs O(m * n) workspace,
+> which it does for the `syev` and `gesvd` routines.
+
+Preprocessing Macros
+--------------------
+
+Do not use macros for anything else than:
+
+* conditionally including software dependencies,
+* guards in header files preventing multiple inclusion.
+
+This code summarizes the legitimate uses of macros:
+
+```
+#!cpp
+
+#ifndef ICL_PTHREAD_H
+#define ICL_PTHREAD_H
+
+#ifndef __APPLE__
+#include <pthread.h>
+#else
+#include <libkern/OSAtomic.h>
+
+...
+
+#endif // __APPLE__
+#endif // ICL_PTHREAD_H
+```
+
+Check out the
+[Google Style Guide](https://google.github.io/styleguide/cppguide.html#Preprocessor_Macros)
+for more explanations.
+
+Concurrency
+===========
+
+* POSIX Threads (Pthreads) and OpenMP are preferred ways of multithreading.
+  Do not refrain from using recent features. The bottom line is: if it is
+  supported in GCC, it is okay to use.
+
+* Prefer spinlocks over regular locks.
+  There is no reason for doing otherwise for high performance parallel codes.
+
+* Use [GNU atomic builtins](https://gcc.gnu.org/onlinedocs/gcc-4.4.3/gcc/Atomic-Builtins.html)
+  to implement low-level synchronization mechanisms.
+  They are supported by all major compilers (GNU, Intel).
+
+* Declare all synchronization variables as `volatile`, even if you are
+  only accessing them using atomic builtins.
+  If a variable can be accessed by more than one thread, it needs to be
+  `volatile` to prevent compiler from applying optimizations that might result
+  in incorrect code.
+
+* If you find yourself considering the use of memory barriers,
+  you went too low-level. Use atomic builtins or spinlocks instead.
+
+Building with Missing Dependencies
+==================================
+
+If a certain environment is missing a mainstream component,
+e.g., Pthread spinlocks on OSX, do not create a new abstraction layer,
+but implement the missing functions on top of the available native functions
+(e.g., PLASMA on MS Windows, PULSAR on OSX).
+
+```
+#!cpp
+
+#ifndef __APPLE__
+#include <pthread.h>
+#else
+#include <libkern/OSAtomic.h>
+
+typedef OSSpinLock pthread_spinlock_t;
+
+inline int pthread_spin_lock(pthread_spinlock_t *lock) {
+    OSSpinLockLock(lock);
+    return 0;
+}
+...
+#endif // __APPLE__
+```
+
+Similar principle applies when a component is completely missing.
+Use the API as if the component was there.
+Provide a header file with stubs for the missing functions.
+Write your code such that it works correctly if stubs are called
+instead of the missing component.
+PULSAR is written that way with respect to support for MPI and CUDA.
+It may not always be possible, but at least investigate the possibility.
+
+Naming
+======
+
+* Use abbreviations within reason. Follow common conventions.
+  Name a variable `retval` rather than `return_value`.
+
+* There are no special requirements for global variables,
+  which should be rare anyway, but if you use them, consider prefixing them
+  with `g_` or some other marker to easily distinguish it from local variables.
+
+File Names
+----------
+
+Most projects already have a convention.
+Follow the project's convention.
+
+In C++ the file name should match the class name.
+Consider using the Trilinos convention:
+`<NameSpace>_<ClassName>`, i.e., namespace using Pascal case,
+underscore, class name using Pascal case,
+e.g., `IclMagma_SomeClass.hh`, `IclMagma_SomeClass.cc`.
+
+Use `.h` and `.c` extensions for C files, and `.hh` and `.cc` for C++ files.
+
+Type Names
+----------
+
+* In C++ use Pascal case for class names, e.g., `MyExcitingClass`.
+
+* In C use camel case for type names followed by `_t`, e.g., `myExcitingType_t`
+  (NVIDIA's convention).
+
+Wrap enums and structs in typedefs and do not use `enum` and `struct` keywords
+when declaring variables.
+
+Variable Names
+--------------
+
+* The names of variables and data members are all lowercase,
+  with underscores between words.
+  Data members of classes (but not structs) additionally have trailing underscores.
+  For instance:
+
+    - `a_local_variable`,
+    - `a_struct_data_member`,
+    - `a_class_data_member_`.
+
+Constant Names
+--------------
+
+Use Pascal case for constants, i.e., `const int ArraySize`.
+
+> This is Microsoft's convention.
+> Google's convention is to use a leading `k`, i.e., `kArraySize`,
+> which seems a little arbitrary and looks somewhat awkward.
+
+Prefix global variables with `g_` and global constants with `G_`, e.g.,
+`g_scary_global_variable`, `G_ScaryGlobalConstant`.
+
+Function Names
+--------------
+
+Use snake case for C function names and C++ method names,
+e.g., `my_awesome_c_function`, `my_awesome_cpp_method`.
+
+Namespace Names
+---------------
+
+Namespace names are Pascal case (Trilinos, Microsoft).
+
+Enumerator Names
+----------------
+
+Individual enumerators should be named like constants, i.e., Pascal case.
+
+Macro Names
+-----------
+
+1. Do not use macros.
+
+2. If you really need to use a macro, see 1.
+
+Comments
+========
+
+* Use C99/C++ style `//` comments.
+
+* Comment your code heavily, but do not state the obvious.
+
+* If a comment is a sentence, start with a capital letter and end with a period.
+
+* If a comment is not a sentence, start with a small letter and do not end with a period.
+
+* Start each file with a boilerplate.
+
+* Do not duplicate comments in both the `.hh` and the `.cc` file.
+  Duplicated comments diverge.
+
+Function Comments
+-----------------
+
+Use Doxygen (`///`) for function comments:
+
+* Start with `@brief`,
+* Follow with extended description if necessary, indented one more space
+  than `@`.
+* Follow with parameters and indicate direction (in, out, inout),
+* Follow with return values,
+* Separate the name of the parameter from the description with a dash,
+* Do not capitalize the description,
+* Do not follow with a period.
+
+```
+#!cpp
+
+///
+/// @brief Solves a complex problem.
+///
+///  Uses such and such algorith
+///  with such and such properties.
+///
+/// @param[in] n - array size
+/// @param[in] array - array of input data
+/// ...
+/// @param[out] result - array of output data
+///
+/// @returns error code
+///
+```
+
+Use `@retval` for a list of discrete return values.
+
+```
+#!cpp
+
+/// @retval  0 - success
+/// @retval -1 - failure
+```
+
+The descriptions should be declarative ("Solves a problem.")
+rather than imperative ("Solve a problem").
+This is the convention of Google, and also LAPACK.
+
+If the function does something trivial, just skip the comment.
+It is quite common for destructors not to have header comments.
+
+Variable Comments
+-----------------
+
+* Local variables should have names descriptive enough to not require comments.
+
+* Use Doxygen (`///<`) for data members of classes and structures.
+
+Implementation Comments
+-----------------------
+
+Use standard C++ (`//`) comments (not Doxygen) for implementation comments.
+Put the comments before the codes.
+Do not use inline comments. They make the code harder to read and make it hard
+to respect the 80-characters line limit.
+
+TODO Comments
+-------------
+
+Use the Doxygen `@todo` tag for code that is temporary, a short-term solution,
+or good-enough but not perfect.
+
+```
+#!cpp
+
+// @todo Make it better.
+// @todo (Jakub) Make it even better.
+// @todo (kurzak@eecs.utk.edu) Make it yet better.
+```
+
+Formatting
+==========
+
+Line Length
+-----------
+
+Each line of text in your code should be at most 80 characters long.
+
+> It is a Google rule and is easier to follow than you may think.
+> [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Line_Length)
+> gives some good reasons for this rule.
+> Many ICL projects are pretty good at following this rule.
+
+Indentation
+-----------
+
+Use only spaces (no tabs), and indent 4 spaces at a time.
+
+Most editors can be configured to insert spaces instead of tabs.
+For vim, put these in ~/.vimrc:
+```
+"set shiftwidth=4
+"set softtabstop=4
+"set expandtab
+```
+
+For emacs, put these in ~/.emacs:
+```
+(setq-default c-default-style "k&r"
+              c-basic-offset 4
+              tab-width 4
+              indent-tabs-mode nil)
+```
+
+For jedit, set Tab width to 4 and check "Soft (emulated with spaces) tabs"
+
+Function Declarations and Definitions
+-------------------------------------
+
+Use one of the following styles in declarations and definitions of functions
+that don't fit in a single line:
+
+```
+#!cpp
+
+ReturnType ClassName::ReallyLongFunctionName(Type par_name1, Type par_name2,
+                                             Type par_name3)
+{
+    DoSomething();
+    ...
+}
+```
+
+```
+#!cpp
+
+ReturnType ClassName::ReallyLongFunctionName(
+    Type par_name1, Type par_name2, Type par_name3)
+{
+    DoSomething();
+    ...
+}
+```
+
+```
+#!cpp
+
+ReturnType ClassName::ReallyLongFunctionName(
+    Type par_name1,
+    Type par_name2,
+    Type par_name3)
+{
+    DoSomething();
+    ...
+}
+```
+
+Some points to note:
+
+* Choose good parameter names.
+  Try to be consistent with existing codes (e.g., LAPACK) or literature.
+
+* Never omit parameter names in declarations.
+
+* The open parenthesis is always on the same line as the function name.
+
+* There is never a space between the parentheses and the parameters.
+
+* The open curly brace is always on the start of the next line after
+  function declaration.
+  The exception to the rule are really short functions, e.g., accessors
+  in the body of a class.
+  If this is the case, then everything can be in a single line
+  (if it fits in the 80-characters limit).
+  There should be a space between the close parenthesis
+  and the open curly brace.
+
+* The close curly brace is either on the last line by itself
+  or on the same line as the open curly brace.
+
+Function Calls
+--------------
+
+Use one of the following styles when calling functions
+that don't fit in a single line:
+
+```
+#!cpp
+
+bool result = ReallyLongFunctionName(ReallyLongArguent1,
+                                     ReallyLongArguent2,
+                                     ReallyLongArguent3);
+```
+
+```
+#!cpp
+
+bool result = ReallyLongFunctionName(
+    ReallyLongArguent1, ReallyLongArguent2, ReallyLongArguent3);
+```
+
+```
+#!cpp
+
+bool result = ReallyLongFunctionName(
+    ReallyLongArguent1,
+    ReallyLongArguent2,
+    ReallyLongArguent3);
+```
+
+```
+#!cpp
+
+bool result =
+    ReallyLongFunctionName(
+        ReallyLongArguent1,
+        ReallyLongArguent2,
+        ReallyLongArguent3);
+```
+
+Functions may have natural line breaking patterns, e.g.:
+
+```
+#!cpp
+
+cblas_dgemm(
+    CblasColMajor,
+    CblasNoTrans, CblasNoTrans,
+    m, n, k,
+    1.0, a, lda,
+         b, ldb,
+    1.0, c, ldc);
+```
+
+Conditionals
+------------
+
+The boilerplate for conditionals is:
+
+```
+#!cpp
+
+if (condition) {
+    ...
+}
+else if (...) {
+    ...
+}
+else {
+    ...
+}
+```
+
+Note:
+
+* a space between `if` and the opening parenthesis,
+* no spaces inside the parentheses,
+* the opening curly brace in the same line,
+* a space between the closing parenthesis and the opening curly brace,
+* closing curly brace in a separate line,
+* `else` in the next line after the closing curly brace,
+* the opening curly brace of `else` in the same line after a space,
+* same goes for `else if`.
+
+Short conditional statements may be written on one line
+if this enhances readability.
+
+```
+#!cpp
+
+if (x == foo) return bar;
+```
+
+This is not allowed when the `if` statement has an `else`.
+
+Curly braces are not required for single-line statements.
+However, if one part of an if-else statement uses curly braces,
+the other part must too.
+
+Loops
+-----
+
+The boilerplates for loops are:
+
+```
+#!cpp
+
+for (int i = 0; i < SomeNumber; i++)
+    ...
+
+for (int i = 0; i < SomeNumber; i++) {
+    ...
+}
+```
+
+```
+#!cpp
+
+while (condition)
+    ...
+
+while (condition) {
+    ...
+}
+
+do {
+    ...
+} while (condition);
+```
+
+Switch
+------
+
+The boilerplate for `switch` is:
+
+```
+#!cpp
+
+switch (var) {
+case 0:
+    ...
+    break;
+case 0:
+    ...
+    break;
+default:
+    assert(false);
+}
+```
+
+If the default case should never execute, simply assert false.
+
+Pointer and Reference Expressions
+---------------------------------
+
+No spaces around period or arrow. Pointer operators do not have trailing spaces.
+The following are examples of correctly-formatted pointer and reference expressions:
+
+```
+#!cpp
+
+x = *p;
+p = &x;
+x = r.y;
+x = r->y;
+```
+
+Note that:
+
+* There are no spaces around the period or arrow when accessing a member.
+* Pointer operators have no space after the * or &.
+
+When declaring a pointer variable or argument, always place the asterisk
+adjacent to the variable name:
+
+```
+#!cpp
+
+char *c;
+const string &str;
+```
+
+Boolean Expressions
+-------------------
+
+When you have a boolean expression that is longer than the standard line length,
+break lines like this:
+
+```
+#!cpp
+
+if (this_one_thing > this_other_thing &&
+    a_third_thing == a_fourth_thing &&
+    yet_another && last_one) {
+    ...
+}
+```
+
+Note that when the code wraps in this example, both of the && operators
+are at the end of the line.
+Also note that you should always use the punctuation operators,
+such as && and ~, rather than the word operators, such as `and` and `compl`.
+
+Return Values
+-------------
+
+Do not needlessly surround the `return` expression with parentheses.
+Use parentheses in `return expr`; only where you would use them in `x = expr;`.
+
+```
+#!cpp
+
+return result;
+
+return (some_long_condition && another_condition);
+```
+
+Preprocessor Directives
+-----------------------
+
+The hash mark that starts a preprocessor directive should always be
+at the beginning of the line.
+Even when preprocessor directives are within the body of indented code,
+the directives should start at the beginning of the line.
+
+Class Format
+------------
+
+The class boilerplate is:
+
+```
+#!cpp
+
+class MyClass {
+    friend class FriendClass;
+
+public:
+    MyClass(int value) : value_(value), pointer_(NULL) {}
+    ~MyClass();
+
+    int getValue() { return value_; }
+    int getPointer() { return pointer_; }
+
+    void awesomePublicMethod();
+    void anotherPublicMethod();
+
+private:
+    void awesomeSecretMethod();
+    void anotherSecretMethod();
+
+    int value_;
+    int *poiter_;
+};
+```
+
+Note that:
+
+* The `friend` keyword is indented.
+* The `private` and `public` keywords are not indented.
+* Except for the first instance, these keywords are preceded by a blank line.
+* There are no blank lines after these keywords.
+* The `friend` section is first, followed by the `public` section
+  and the `private` section.
+* In the private section, methods are first, followed by attributes.
+
+> This is the order of the
+> [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Class_Format),
+> the Trilinos project, and also Doxygen produces documentation
+> in this order.
+>
+> The order of methods is top to bottom, e.g., the deeper in the call tree
+> the lower on the list. This applies both to the order of declarations
+> and the order or definitions, which should be identical.
+
+Constructor Initializer Lists
+-----------------------------
+
+Constructor initializer lists can be all on one line or with subsequent lines
+indented four spaces.
+The acceptable formats for initializer lists are:
+
+```
+#!cpp
+
+    MyClass(int value)
+        : value_(value), pointer_(NULL)
+    {
+        ...
+    }
+
+    MyClass(int value)
+        : value_(value),
+          pointer_(NULL)
+    {
+        ...
+    }
+```
+
+In each case the closing curly brace can be in the same line as the opening
+curly brace if it fits.
+
+> Initialization list is part of constructor's definition,
+> so you need to define it at the same place you define constructor's body.
+
+Namespace Formatting
+--------------------
+
+The contents of namespaces are not indented.
+
+When declaring nested namespaces, put each namespace on its own line.
+
+```
+#!cpp
+
+namespace Icl {
+namespace Magma {
+
+...
+
+} // namespace Magma
+} // namespace Icl
+```
+
+Horizontal Whitespace
+---------------------
+
+* Never put trailing whitespace at the end of a line.
+> Trailing whitespace can cause extra work for others editing the same file,
+> when they merge.
+
+* Opening curly braces should always have a space before them.
+
+* Semicolons have no space before them.
+
+* Put spaces around the colon in initializer lists.
+  The same applies for inheritance if you end up using it.
+
+* For inline function implementations, put spaces between the braces
+  and the implementation itself.
+
+* No spaces inside empty parentheses and curly braces.
+
+* Put space after the keyword in conditions and loops.
+
+* `for` loops always have a space after the semicolon,
+  and never a space before the semicolon.
+
+* No space before colon in a `switch` case.
+  A space after a colon if there's code after it.
+
+* Assignment operators always have spaces around them.
+
+* Other binary operators usually have spaces around them, but it's
+  okay to remove spaces around factors.
+  Parentheses should have no internal padding.
+
+* No spaces separating unary operators and their arguments.
+
+```
+#!cpp
+
+x = 0;
+
+v = w * x + y / z;
+v = w*x + y/z;
+v = w * (x + z);
+
+x = -5;
+++x;
+if (x && !y)
+    ...
+```
+
+* In templates, no spaces inside the angle brackets.
+  No spaces between type and pointer.
+  C++11 notation for nesting.
+
+```
+#!cpp
+
+vector<string> x;
+
+y = static_cast<char*>(x);
+
+vector<char*> x;
+
+set<list<string>> x;
+```
+
+Vertical Whitespace
+-------------------
+
+* Never use more than a single blank line.
+
+Horizontal Rules
+----------------
+
+* Horizontal rules are great.
+  Use whatever works for you.
+  Be consistent throughout each project.
+  Make them 80 characters wide.
+
+```
+#!cpp
+
+//------------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////
+
+/******************************************************************************/
+```

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -38,19 +38,15 @@ General Guidelines
 * If you spot inconsistencies, fix them.
 * Break rules if it helps readability. This is only a guide.
 
-> Established ICL projects (PLASMA, MAGMA, PaRSEC, PAPI) already have their
-> conventions. In most cases, existing project conventions override conventions
-> in this guide. Unless, you can fix bad practices in an existing project by consistently
-> applying a better convention across the entire source code, a task which can sometimes
-> be automated.
->
-> Definitely follow this guide if starting a new project or a prototype.
+> This guide was written for PLASMA. Other ICL projects have their own
+> conventions. A few differences with SLATE's style are noted here.
 
-Standard Compliance
-===================
+Standards Compliance
+====================
 
 C codes should be C99 compliant and compiled with the `-std=c99` flag,
-and C++ codes should be C++11 compliant and compiled with the `-std=c++11` flag.
+and C++ codes should be C++11 compliant and compiled with the `-std=c++11` flag
+(or later).
 
 Avoid features present only in C but not in C++. That is, C code should compile with either C or C++ compiler.
 
@@ -70,32 +66,31 @@ Files that are meant for textual inclusion, but are not headers, should end in `
 > Therefore, we use `.c` and `.h` for C and `.cc` and `.hh` for C++.
 >
 > Trilinos uses another common convention of `.cpp` and `.hpp`.
-> However, in a long list of files, this puts a lot of <p>s on the screen.
+> However, in a long list of files, this puts a lot of p's on the screen.
 > The `.cc` and `.hh` endings are shorter and cleaner.
 
 \#define Guards
 --------------
 
 All header files should have `#define` guards to prevent multiple inclusion.
-The format of the symbol name should be `<ICL>_<PROJECT>_<FILE>_H` for C
-and `<ICL>_<PROJECT>_<FILE>_HH` for C++.
+The format of the symbol name should be `<PROJECT>_<FILE>_H` for C
+and `<PROJECT>_<FILE>_HH` for C++.
 
 ```
 #!cpp
 
-#ifndef ICL_MAGMA_BLAS_H
-#define ICL_MAGMA_BLAS_H
+#ifndef PLASMA_BLAS_H
+#define PLASMA_BLAS_H
 
 ...
 
-#endif // ICL_MAGMA_BLAS_H
+#endif // PLASMA_BLAS_H
 ```
 
 > Google uses an underscore at the end.
-> Some projects use an underscore at the beginning and an underscore at the end.
 > Trilinos does not use underscores.
 > In the case of header guards, beginning/ending underscores seem pointless.
-> Underscores in front of a name are used for system-level hacking.
+> Underscores in front of a name are reserved for system-level headers.
 
 extern C
 --------
@@ -131,7 +126,7 @@ Inline Functions
 
 Mark small functions as inline, specifically those that serve as macro replacements.
 Although the compiler will identify on its own functions
-suitable for inlining, it is a good idea hint it directly.
+suitable for inlining, it is a good idea to hint it directly.
 Define as inline member accessors and functions that would otherwise be macros,
 e.g., address arithmetic functions and alike.
 Check [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Inline_Functions)
@@ -190,7 +185,6 @@ Keep your system-specific code small and localized.
 #include <libkern/OSAtomic.h>
 
 ...
-
 #endif // __APPLE__
 ```
 
@@ -200,13 +194,14 @@ Scoping
 Namespaces
 ----------
 
-With few exceptions, place code in a namespace.
+With few exceptions, place C++ code in a namespace.
 Use named namespaces as follows:
 
 * Namespaces wrap the entire source file after includes.
-* Do not declare anything in namespace std, including forward declarations
-  of standard library classes. Declaring entities in namespace std is undefined
-  behavior. To declare entities from the standard library, include the appropriate
+* Do not declare anything in namespace `std`, including forward declarations
+  of standard library classes. Declaring entities in namespace `std` is undefined
+  behavior (unless specifically allowed in the C++ standard).
+  To declare entities from the standard library, include the appropriate
   header file.
 * Do not use a `using` directive to make all names from a namespace available.
 * Do not use `using` declarations in `.hh` files, because anything imported
@@ -218,30 +213,28 @@ Use named namespaces as follows:
 * Use Pascal case for namespace components.
 
 Namespaces should have unique names based on the project name.
-Generic components, that may be shared among multiple projects, such as, e.g.,
+Generic components, that may be shared among multiple projects, such as
 an efficient implementation of a thread-safe hash table, may be placed in
-a namespace `Icl`, while project-specific components may be placed
-in a namespace, e.g., `Icl::Magma`.
+a namespace `icl`, while project-specific components must be placed
+in a namespace, e.g., `plasma`.
 
 Format namespaces in `.hh` files as follows:
 
 ```
 #!cpp
 
-#ifndef ICL_MAGMA_HH
-#define ICL_MAGMA_HH
+#ifndef PLASMA_HH
+#define PLASMA_HH
 
 #include <cuda.h>
 
-namespace Icl {
-namespace Magma {
+namespace plasma {
 
 ...
 
-} // namespace Magma
-} // namespace Icl
+} // namespace plasma
 
-#endif // ICL_MAGMA_HH
+#endif // PLASMA_HH
 ```
 
 Nonmember, Static Member, and Global Functions
@@ -358,7 +351,7 @@ should be handled as follows:
 
 * Be self-contained, i.e., contain all memory pointers.
 
-* Set all memory pointers to NULL at the time of initialization
+* Set all memory pointers to `NULL` (`nullptr` in C++) at the time of initialization
   (in the constructor in C++).
   Rely on constructors or factory methods or `Init()` methods to perform
   allocations and initializations.
@@ -419,6 +412,11 @@ Other C++ Features
   of the space.
   And also, the proper name of `long` is `long int`, which also includes the space.
 
+> SLATE uses C++ style casts, which are clearer about what expression
+> the cast applies to, e.g., `(int) x * y` is the same as `int( x ) * y`,
+> not `int( x * y )`. For `long long`, SLATE has a typedef `llong` so that
+> `llong( x )` works. Otherwise, `(long long)( x )` works.
+
 * Do not use C++ streams.
   Use C standard IO functions instead.
   C++ streams are cumbersome and the
@@ -426,7 +424,8 @@ Other C++ Features
   provides a long list of reasons why.
 
 * Use preincrement/predecrement (`++i`) as opposed to postincrement/postdecrement (`i++`).
-  This is a common C++ convention.
+  This is a common C++ convention since postincrement introduces a
+  needless temporary return value that can be expensive for C++ classes.
 
 * Use the following notations when initializing variables:
   `1` for integers, `1.0` for doubles, `1.0f` for floats, `0x01` for bit patterns.
@@ -482,7 +481,7 @@ Pick one way or the other and stick to it.
 
 If you use exceptions, list exceptions in function comments, but not in signatures.
 Listing in signatures is a bad idea (http://www.gotw.ca/publications/mill22.htm),
-and it is deprected in C++11.
+and it is deprecated in C++11.
 
 Integer Types
 -------------
@@ -513,7 +512,8 @@ required, e.g., to minimize the memory footprint of a large array.
 NULL, nullptr, 0
 ----------------
 
-In C++ use nullptr - removes ambiguity. You can take sizeof(nullptr).
+In C++ use `nullptr`, which removes ambiguity. `NULL` is an integer (0);
+`nullptr` is a pointer. You can take `sizeof(nullptr)`.
 
 64-bit Addressing
 -----------------
@@ -564,6 +564,7 @@ This code summarizes the legitimate uses of macros:
 ...
 
 #endif // __APPLE__
+
 #endif // ICL_PTHREAD_H
 ```
 
@@ -585,17 +586,29 @@ Concurrency
   to implement low-level synchronization mechanisms.
   They are supported by all major compilers (GNU, Intel).
 
-* Declare all synchronization variables as `volatile`, even if you are
+> SLATE uses C++ `std::atomic`.
+
+* <strike> Declare all synchronization variables as `volatile`, even if you are
   only accessing them using atomic builtins.
   If a variable can be accessed by more than one thread, it needs to be
   `volatile` to prevent compiler from applying optimizations that might result
-  in incorrect code.
+  in incorrect code. </strike>
+
+> This misunderstands `volatile`. Read Scott Meyers, "Effective Modern C++",
+> Item 40: Use `std::atomic` for concurrency, `volatile` for special memory
+> (e.g. memory-mapped I/O).
 
 * If you find yourself considering the use of memory barriers,
   you went too low-level. Use atomic builtins or spinlocks instead.
 
 Building with Missing Dependencies
 ==================================
+
+> !!! This section violates xSDK policies such as (M9) using a
+> well-defined name space and (M12) linking with external dependencies.
+> Consider a library linked with stub MPI or OpenMP functions; it cannot
+> be used in an application that links with real MPI or OpenMP due to
+> name collisions. !!!
 
 If a certain environment is missing a mainstream component,
 e.g., Pthread spinlocks on OSX, do not create a new abstraction layer,
@@ -648,7 +661,7 @@ In C++ the file name should match the class name.
 Consider using the Trilinos convention:
 `<NameSpace>_<ClassName>`, i.e., namespace using Pascal case,
 underscore, class name using Pascal case,
-e.g., `IclMagma_SomeClass.hh`, `IclMagma_SomeClass.cc`.
+e.g., `Magma_SomeClass.hh`, `Magma_SomeClass.cc`.
 
 Use `.h` and `.c` extensions for C files, and `.hh` and `.cc` for C++ files.
 
@@ -693,10 +706,15 @@ Function Names
 Use snake case for C function names and C++ method names,
 e.g., `my_awesome_c_function`, `my_awesome_cpp_method`.
 
+> SLATE used lowerCamelCase for methods, but there has been discussion
+> to make them snake_case.
+
 Namespace Names
 ---------------
 
 Namespace names are Pascal case (Trilinos, Microsoft).
+
+> SLATE uses lowercase for namespaces.
 
 Enumerator Names
 ----------------
@@ -773,6 +791,8 @@ This is the convention of Google, and also LAPACK.
 
 If the function does something trivial, just skip the comment.
 It is quite common for destructors not to have header comments.
+
+> SLATE skips `@brief` in favor of Doxygen's autobrief feature.
 
 Variable Comments
 -----------------
@@ -1010,10 +1030,10 @@ The boilerplates for loops are:
 ```
 #!cpp
 
-for (int i = 0; i < SomeNumber; i++)
+for (int i = 0; i < SomeNumber; ++i)
     ...
 
-for (int i = 0; i < SomeNumber; i++) {
+for (int i = 0; i < SomeNumber; ++i) {
     ...
 }
 ```
@@ -1055,6 +1075,8 @@ default:
 
 If the default case should never execute, simply assert false.
 
+> SLATE indents `case` statements one level, since they're inside a block.
+
 Pointer and Reference Expressions
 ---------------------------------
 
@@ -1085,6 +1107,8 @@ char *c;
 const string &str;
 ```
 
+> SLATE places * and & next to the type, since it is part of the type.
+
 Boolean Expressions
 -------------------
 
@@ -1105,6 +1129,11 @@ Note that when the code wraps in this example, both of the && operators
 are at the end of the line.
 Also note that you should always use the punctuation operators,
 such as && and ~, rather than the word operators, such as `and` and `compl`.
+
+> SLATE places operators at the beginning of the line for clarity,
+> consistent with math typesetting conventions.
+> (Although older SLATE code doesn't.)
+> See AMS "Mathematics into Type", section 3.3.5.
 
 Return Values
 -------------
@@ -1128,6 +1157,9 @@ at the beginning of the line.
 Even when preprocessor directives are within the body of indented code,
 the directives should start at the beginning of the line.
 
+> SLATE indents preprocessor directives and code inside #if ... #else ... #endif
+> for improved readability (excluding header guards).
+
 Class Format
 ------------
 
@@ -1140,18 +1172,18 @@ class MyClass {
     friend class FriendClass;
 
 public:
-    MyClass(int value) : value_(value), pointer_(NULL) {}
+    MyClass(int value) : value_(value), pointer_(nullptr) {}
     ~MyClass();
 
-    int getValue() { return value_; }
-    int getPointer() { return pointer_; }
+    int get_value() { return value_; }
+    int get_pointer() { return pointer_; }
 
-    void awesomePublicMethod();
-    void anotherPublicMethod();
+    void awesome_public_method();
+    void another_public_method();
 
 private:
-    void awesomeSecretMethod();
-    void anotherSecretMethod();
+    void awesome_secret_method();
+    void another_secret_method();
 
     int value_;
     int *poiter_;
@@ -1188,14 +1220,14 @@ The acceptable formats for initializer lists are:
 #!cpp
 
     MyClass(int value)
-        : value_(value), pointer_(NULL)
+        : value_(value), pointer_(nullptr)
     {
         ...
     }
 
     MyClass(int value)
         : value_(value),
-          pointer_(NULL)
+          pointer_(nullptr)
     {
         ...
     }
@@ -1217,13 +1249,13 @@ When declaring nested namespaces, put each namespace on its own line.
 ```
 #!cpp
 
-namespace Icl {
-namespace Magma {
+namespace plasma {
+namespace internal {
 
 ...
 
-} // namespace Magma
-} // namespace Icl
+} // namespace internal
+} // namespace plasma
 ```
 
 Horizontal Whitespace
@@ -1245,7 +1277,7 @@ Horizontal Whitespace
 
 * No spaces inside empty parentheses and curly braces.
 
-* Put space after the keyword in conditions and loops.
+* Put space after the keyword in conditionals and loops.
 
 * `for` loops always have a space after the semicolon,
   and never a space before the semicolon.

--- a/include/plasma_core_blas_z.h
+++ b/include/plasma_core_blas_z.h
@@ -30,189 +30,222 @@ extern "C" {
 double plasma_core_dcabs1(plasma_complex64_t alpha);
 #endif
 
-void plasma_core_zgbtype1cb(plasma_enum_t uplo, int n, int nb,
-                      plasma_complex64_t *A, int lda,
-                      plasma_complex64_t *VQ, plasma_complex64_t *TAUQ,
-                      plasma_complex64_t *VP, plasma_complex64_t *TAUP,
-                      int st, int ed, int sweep, int Vblksiz, int WANTZ,
-                      plasma_complex64_t *work);
-    
-void plasma_core_zgbtype2cb(plasma_enum_t uplo, int n, int nb,
-                      plasma_complex64_t *A, int lda,
-                      plasma_complex64_t *VQ, plasma_complex64_t *TAUQ,
-                      plasma_complex64_t *VP, plasma_complex64_t *TAUP,
-                      int st, int ed, int sweep, int Vblksiz, int WANTZ,
-                      plasma_complex64_t *work);
-    
-void plasma_core_zgbtype3cb(plasma_enum_t uplo, int n, int nb,
-                      plasma_complex64_t *A, int lda,
-                      plasma_complex64_t *VQ, plasma_complex64_t *TAUQ,
-                      plasma_complex64_t *VP, plasma_complex64_t *TAUP,
-                      int st, int ed, int sweep, int Vblksiz, int WANTZ,
-                      plasma_complex64_t *work);
-    
-int plasma_core_zgeadd(plasma_enum_t transa,
-                int m, int n,
-                plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                plasma_complex64_t beta,        plasma_complex64_t *B, int ldb);
+void plasma_core_zgbtype1cb(
+    plasma_enum_t uplo, int n, int nb,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *VQ, plasma_complex64_t *TAUQ,
+    plasma_complex64_t *VP, plasma_complex64_t *TAUP,
+    int st, int ed, int sweep, int Vblksiz, int WANTZ,
+    plasma_complex64_t *work);
 
-int plasma_core_zgelqt(int m, int n, int ib,
-                plasma_complex64_t *A, int lda,
-                plasma_complex64_t *T, int ldt,
-                plasma_complex64_t *tau,
-                plasma_complex64_t *work);
+void plasma_core_zgbtype2cb(
+    plasma_enum_t uplo, int n, int nb,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *VQ, plasma_complex64_t *TAUQ,
+    plasma_complex64_t *VP, plasma_complex64_t *TAUP,
+    int st, int ed, int sweep, int Vblksiz, int WANTZ,
+    plasma_complex64_t *work);
 
-void plasma_core_zgemm(plasma_enum_t transa, plasma_enum_t transb,
-                int m, int n, int k,
-                plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                                          const plasma_complex64_t *B, int ldb,
-                plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
+void plasma_core_zgbtype3cb(
+    plasma_enum_t uplo, int n, int nb,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *VQ, plasma_complex64_t *TAUQ,
+    plasma_complex64_t *VP, plasma_complex64_t *TAUP,
+    int st, int ed, int sweep, int Vblksiz, int WANTZ,
+    plasma_complex64_t *work);
 
-int plasma_core_zgeqrt(int m, int n, int ib,
-                plasma_complex64_t *A, int lda,
-                plasma_complex64_t *T, int ldt,
-                plasma_complex64_t *tau,
-                plasma_complex64_t *work);
+int plasma_core_zgeadd(
+    plasma_enum_t transa,
+    int m, int n,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+    plasma_complex64_t beta,        plasma_complex64_t *B, int ldb);
 
-void plasma_core_zgessq(int m, int n,
-                 const plasma_complex64_t *A, int lda,
-                 double *scale, double *sumsq);
+int plasma_core_zgelqt(
+    int m, int n, int ib,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *T, int ldt,
+    plasma_complex64_t *tau,
+    plasma_complex64_t *work);
 
-void plasma_core_zgetrf(plasma_desc_t A, int *ipiv, int ib, int rank, int size,
-                 volatile int *max_idx, volatile plasma_complex64_t *max_val,
-                 volatile int *info, plasma_barrier_t *barrier);
+void plasma_core_zgemm(
+    plasma_enum_t transa, plasma_enum_t transb,
+    int m, int n, int k,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+                              const plasma_complex64_t *B, int ldb,
+    plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
 
-int plasma_core_zhegst(int itype, plasma_enum_t uplo,
-                int n,
-                plasma_complex64_t *A, int lda,
-                plasma_complex64_t *B, int ldb);
+int plasma_core_zgeqrt(
+    int m, int n, int ib,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *T, int ldt,
+    plasma_complex64_t *tau,
+    plasma_complex64_t *work);
 
-void plasma_core_zhemm(plasma_enum_t side, plasma_enum_t uplo,
-                int m, int n,
-                plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                                          const plasma_complex64_t *B, int ldb,
-                plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
+void plasma_core_zgessq(
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *scale, double *sumsq);
 
-void plasma_core_zher2k(plasma_enum_t uplo, plasma_enum_t trans,
-                 int n, int k,
-                 plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                                           const plasma_complex64_t *B, int ldb,
-                 double beta,                    plasma_complex64_t *C, int ldc);
+void plasma_core_zgetrf(
+    plasma_desc_t A, int *ipiv, int ib, int rank, int size,
+    volatile int *max_idx, volatile plasma_complex64_t *max_val,
+    volatile int *info, plasma_barrier_t *barrier);
 
-void plasma_core_zherk(plasma_enum_t uplo, plasma_enum_t trans,
-                int n, int k,
-                double alpha, const plasma_complex64_t *A, int lda,
-                double beta,        plasma_complex64_t *C, int ldc);
+int plasma_core_zhegst(
+    int itype, plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *B, int ldb);
 
-void plasma_core_zhessq(plasma_enum_t uplo,
-                 int n,
-                 const plasma_complex64_t *A, int lda,
-                 double *scale, double *sumsq);
+void plasma_core_zhemm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    int m, int n,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+                              const plasma_complex64_t *B, int ldb,
+    plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
 
-void plasma_core_zsyssq(plasma_enum_t uplo,
-                 int n,
-                 const plasma_complex64_t *A, int lda,
-                 double *scale, double *sumsq);
+void plasma_core_zher2k(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    int n, int k,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+                              const plasma_complex64_t *B, int ldb,
+    double beta,                    plasma_complex64_t *C, int ldc);
 
-void plasma_core_zlacpy(plasma_enum_t uplo, plasma_enum_t transa,
-                 int m, int n,
-                 const plasma_complex64_t *A, int lda,
-                       plasma_complex64_t *B, int ldb);
+void plasma_core_zherk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    int n, int k,
+    double alpha, const plasma_complex64_t *A, int lda,
+    double beta,        plasma_complex64_t *C, int ldc);
 
-void plasma_core_zlacpy_lapack2tile_band(plasma_enum_t uplo,
-                                  int it, int jt,
-                                  int m, int n, int nb, int kl, int ku,
-                                  const plasma_complex64_t *A, int lda,
-                                        plasma_complex64_t *B, int ldb);
+void plasma_core_zhessq(
+    plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *scale, double *sumsq);
 
-void plasma_core_zlacpy_tile2lapack_band(plasma_enum_t uplo,
-                                  int it, int jt,
-                                  int m, int n, int nb, int kl, int ku,
-                                  const plasma_complex64_t *B, int ldb,
-                                        plasma_complex64_t *A, int lda);
+void plasma_core_zsyssq(
+    plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *scale, double *sumsq);
 
-void plasma_core_zlange(plasma_enum_t norm,
-                 int m, int n,
-                 const plasma_complex64_t *A, int lda,
-                 double *work, double *result);
+void plasma_core_zlacpy(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    plasma_complex64_t *B, int ldb);
 
-void plasma_core_zlanhe(plasma_enum_t norm, plasma_enum_t uplo,
-                 int n,
-                 const plasma_complex64_t *A, int lda,
-                 double *work, double *value);
+void plasma_core_zlacpy_lapack2tile_band(
+    plasma_enum_t uplo,
+    int it, int jt,
+    int m, int n, int nb, int kl, int ku,
+    const plasma_complex64_t *A, int lda,
+    plasma_complex64_t *B, int ldb);
 
-void plasma_core_zlansy(plasma_enum_t norm, plasma_enum_t uplo,
-                 int n,
-                 const plasma_complex64_t *A, int lda,
-                 double *work, double *value);
+void plasma_core_zlacpy_tile2lapack_band(
+    plasma_enum_t uplo,
+    int it, int jt,
+    int m, int n, int nb, int kl, int ku,
+    const plasma_complex64_t *B, int ldb,
+    plasma_complex64_t *A, int lda);
 
-void plasma_core_zlantr(plasma_enum_t norm, plasma_enum_t uplo, plasma_enum_t diag,
-                 int m, int n,
-                 const plasma_complex64_t *A, int lda,
-                 double *work, double *value);
+void plasma_core_zlange(
+    plasma_enum_t norm,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *work, double *result);
 
-int plasma_core_zlarfb_gemm(plasma_enum_t side, plasma_enum_t trans, int direct, int storev,
-                     int M, int N, int K,
-                     const plasma_complex64_t *V, int LDV,
-                     const plasma_complex64_t *T, int LDT,
-                     plasma_complex64_t *C, int LDC,
-                     plasma_complex64_t *WORK, int LDWORK);
+void plasma_core_zlanhe(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *work, double *value);
 
-void plasma_core_zlascl(plasma_enum_t uplo,
-                 double cfrom, double cto,
-                 int m, int n,
-                 plasma_complex64_t *A, int lda);
+void plasma_core_zlansy(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *work, double *value);
 
-void plasma_core_zlaset(plasma_enum_t uplo,
-                 int m, int n,
-                 plasma_complex64_t alpha, plasma_complex64_t beta,
-                 plasma_complex64_t *A, int lda);
+void plasma_core_zlantr(
+    plasma_enum_t norm, plasma_enum_t uplo, plasma_enum_t diag,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *work, double *value);
 
-void plasma_core_zgeswp(plasma_enum_t colrow,
-                 plasma_desc_t A, int k1, int k2, const int *ipiv, int incx);
+int plasma_core_zlarfb_gemm(
+    plasma_enum_t side, plasma_enum_t trans, int direct, int storev,
+    int M, int N, int K,
+    const plasma_complex64_t *V, int LDV,
+    const plasma_complex64_t *T, int LDT,
+    plasma_complex64_t *C, int LDC,
+    plasma_complex64_t *WORK, int LDWORK);
 
-void plasma_core_zheswp(int rank, int num_threads,
-                 int uplo, plasma_desc_t A, int k1, int k2, const int *ipiv,
-                 int incx, plasma_barrier_t *barrier);
+void plasma_core_zlascl(
+    plasma_enum_t uplo,
+    double cfrom, double cto,
+    int m, int n,
+    plasma_complex64_t *A, int lda);
 
-int plasma_core_zlauum(plasma_enum_t uplo,
-                int n,
-                plasma_complex64_t *A, int lda);
+void plasma_core_zlaset(
+    plasma_enum_t uplo,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t beta,
+    plasma_complex64_t *A, int lda);
 
-int plasma_core_zpamm(plasma_enum_t op, plasma_enum_t side, plasma_enum_t storev,
-               int m, int n, int k, int l,
-               const plasma_complex64_t *A1, int lda1,
-                     plasma_complex64_t *A2, int lda2,
-               const plasma_complex64_t *V,  int ldv,
-                     plasma_complex64_t *W,  int ldw);
+void plasma_core_zgeswp(
+    plasma_enum_t colrow,
+    plasma_desc_t A, int k1, int k2, const int *ipiv, int incx);
 
-int plasma_core_zparfb(plasma_enum_t side, plasma_enum_t trans, plasma_enum_t direct,
-                plasma_enum_t storev,
-                int m1, int n1, int m2, int n2, int k, int l,
-                      plasma_complex64_t *A1,   int lda1,
-                      plasma_complex64_t *A2,   int lda2,
-                const plasma_complex64_t *V,    int ldv,
-                const plasma_complex64_t *T,    int ldt,
-                      plasma_complex64_t *work, int ldwork);
+void plasma_core_zheswp(
+    int rank, int num_threads,
+    int uplo, plasma_desc_t A, int k1, int k2, const int *ipiv,
+    int incx, plasma_barrier_t *barrier);
 
-int plasma_core_zpemv(plasma_enum_t trans, int storev,
-               int m, int n, int l,
-               plasma_complex64_t alpha,
-               const plasma_complex64_t *A, int lda,
-               const plasma_complex64_t *X, int incx,
-               plasma_complex64_t beta,
-               plasma_complex64_t *Y, int incy,
-               plasma_complex64_t *work);
+int plasma_core_zlauum(
+    plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *A, int lda);
 
-int plasma_core_zpotrf(plasma_enum_t uplo,
-                int n,
-                plasma_complex64_t *A, int lda);
+int plasma_core_zpamm(
+    plasma_enum_t op, plasma_enum_t side, plasma_enum_t storev,
+    int m, int n, int k, int l,
+    const plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    const plasma_complex64_t *V,  int ldv,
+    plasma_complex64_t *W,  int ldw);
 
-void plasma_core_zsymm(plasma_enum_t side, plasma_enum_t uplo,
-                int m, int n,
-                plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                                          const plasma_complex64_t *B, int ldb,
-                plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
+int plasma_core_zparfb(
+    plasma_enum_t side, plasma_enum_t trans, plasma_enum_t direct,
+    plasma_enum_t storev,
+    int m1, int n1, int m2, int n2, int k, int l,
+    plasma_complex64_t *A1,   int lda1,
+    plasma_complex64_t *A2,   int lda2,
+    const plasma_complex64_t *V,    int ldv,
+    const plasma_complex64_t *T,    int ldt,
+    plasma_complex64_t *work, int ldwork);
+
+int plasma_core_zpemv(
+    plasma_enum_t trans, int storev,
+    int m, int n, int l,
+    plasma_complex64_t alpha,
+    const plasma_complex64_t *A, int lda,
+    const plasma_complex64_t *X, int incx,
+    plasma_complex64_t beta,
+    plasma_complex64_t *Y, int incy,
+    plasma_complex64_t *work);
+
+int plasma_core_zpotrf(
+    plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *A, int lda);
+
+void plasma_core_zsymm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    int m, int n,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+                              const plasma_complex64_t *B, int ldb,
+    plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
 
 void plasma_core_zsyr2k(
     plasma_enum_t uplo, plasma_enum_t trans,
@@ -221,116 +254,133 @@ void plasma_core_zsyr2k(
                               const plasma_complex64_t *B, int ldb,
     plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
 
-void plasma_core_zsyrk(plasma_enum_t uplo, plasma_enum_t trans,
-                int n, int k,
-                plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
+void plasma_core_zsyrk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    int n, int k,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+    plasma_complex64_t beta,        plasma_complex64_t *C, int ldc);
 
-int plasma_core_ztradd(plasma_enum_t uplo, plasma_enum_t transa,
-                int m, int n,
-                plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                plasma_complex64_t beta,        plasma_complex64_t *B, int ldb);
+int plasma_core_ztradd(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    int m, int n,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+    plasma_complex64_t beta,        plasma_complex64_t *B, int ldb);
 
-void plasma_core_ztrmm(plasma_enum_t side, plasma_enum_t uplo,
-                plasma_enum_t transa, plasma_enum_t diag,
-                int m, int n,
-                plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                                                plasma_complex64_t *B, int ldb);
+void plasma_core_ztrmm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t transa, plasma_enum_t diag,
+    int m, int n,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+                                    plasma_complex64_t *B, int ldb);
 
-void plasma_core_ztrsm(plasma_enum_t side, plasma_enum_t uplo,
-                plasma_enum_t transa, plasma_enum_t diag,
-                int m, int n,
-                plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
-                                                plasma_complex64_t *B, int ldb);
+void plasma_core_ztrsm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t transa, plasma_enum_t diag,
+    int m, int n,
+    plasma_complex64_t alpha, const plasma_complex64_t *A, int lda,
+                                    plasma_complex64_t *B, int ldb);
 
-void plasma_core_ztrssq(plasma_enum_t uplo, plasma_enum_t diag,
-                 int m, int n,
-                 const plasma_complex64_t *A, int lda,
-                 double *scale, double *sumsq);
+void plasma_core_ztrssq(
+    plasma_enum_t uplo, plasma_enum_t diag,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *scale, double *sumsq);
 
-int plasma_core_ztrtri(plasma_enum_t uplo, plasma_enum_t diag,
-                int n,
-                plasma_complex64_t *A, int lda);
+int plasma_core_ztrtri(
+    plasma_enum_t uplo, plasma_enum_t diag,
+    int n,
+    plasma_complex64_t *A, int lda);
 
-int plasma_core_ztslqt(int m, int n, int ib,
-                plasma_complex64_t *A1, int lda1,
-                plasma_complex64_t *A2, int lda2,
-                plasma_complex64_t *T,  int ldt,
-                plasma_complex64_t *tau,
-                plasma_complex64_t *work);
+int plasma_core_ztslqt(
+    int m, int n, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    plasma_complex64_t *T,  int ldt,
+    plasma_complex64_t *tau,
+    plasma_complex64_t *work);
 
-int plasma_core_ztsmlq(plasma_enum_t side, plasma_enum_t trans,
-                int m1, int n1, int m2, int n2, int k, int ib,
-                      plasma_complex64_t *A1,   int lda1,
-                      plasma_complex64_t *A2,   int lda2,
-                const plasma_complex64_t *V,    int ldv,
-                const plasma_complex64_t *T,    int ldt,
-                      plasma_complex64_t *work, int ldwork);
+int plasma_core_ztsmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m1, int n1, int m2, int n2, int k, int ib,
+    plasma_complex64_t *A1,   int lda1,
+    plasma_complex64_t *A2,   int lda2,
+    const plasma_complex64_t *V,    int ldv,
+    const plasma_complex64_t *T,    int ldt,
+    plasma_complex64_t *work, int ldwork);
 
-int plasma_core_ztsmqr(plasma_enum_t side, plasma_enum_t trans,
-                int m1, int n1, int m2, int n2, int k, int ib,
-                      plasma_complex64_t *A1,   int lda1,
-                      plasma_complex64_t *A2,   int lda2,
-                const plasma_complex64_t *V,    int ldv,
-                const plasma_complex64_t *T,    int ldt,
-                      plasma_complex64_t *work, int ldwork);
+int plasma_core_ztsmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m1, int n1, int m2, int n2, int k, int ib,
+    plasma_complex64_t *A1,   int lda1,
+    plasma_complex64_t *A2,   int lda2,
+    const plasma_complex64_t *V,    int ldv,
+    const plasma_complex64_t *T,    int ldt,
+    plasma_complex64_t *work, int ldwork);
 
-int plasma_core_ztsqrt(int m, int n, int ib,
-                plasma_complex64_t *A1, int lda1,
-                plasma_complex64_t *A2, int lda2,
-                plasma_complex64_t *T,  int ldt,
-                plasma_complex64_t *tau,
-                plasma_complex64_t *work);
+int plasma_core_ztsqrt(
+    int m, int n, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    plasma_complex64_t *T,  int ldt,
+    plasma_complex64_t *tau,
+    plasma_complex64_t *work);
 
-int plasma_core_zttlqt(int m, int n, int ib,
-                plasma_complex64_t *A1, int lda1,
-                plasma_complex64_t *A2, int lda2,
-                plasma_complex64_t *T,  int ldt,
-                plasma_complex64_t *tau,
-                plasma_complex64_t *work);
+int plasma_core_zttlqt(
+    int m, int n, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    plasma_complex64_t *T,  int ldt,
+    plasma_complex64_t *tau,
+    plasma_complex64_t *work);
 
-int plasma_core_zttmlq(plasma_enum_t side, plasma_enum_t trans,
-                int m1, int n1, int m2, int n2, int k, int ib,
-                      plasma_complex64_t *A1,   int lda1,
-                      plasma_complex64_t *A2,   int lda2,
-                const plasma_complex64_t *V,    int ldv,
-                const plasma_complex64_t *T,    int ldt,
-                      plasma_complex64_t *work, int ldwork);
+int plasma_core_zttmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m1, int n1, int m2, int n2, int k, int ib,
+    plasma_complex64_t *A1,   int lda1,
+    plasma_complex64_t *A2,   int lda2,
+    const plasma_complex64_t *V,    int ldv,
+    const plasma_complex64_t *T,    int ldt,
+    plasma_complex64_t *work, int ldwork);
 
-int plasma_core_zttmqr(plasma_enum_t side, plasma_enum_t trans,
-                int m1, int n1, int m2, int n2, int k, int ib,
-                      plasma_complex64_t *A1,   int lda1,
-                      plasma_complex64_t *A2,   int lda2,
-                const plasma_complex64_t *V,    int ldv,
-                const plasma_complex64_t *T,    int ldt,
-                      plasma_complex64_t *work, int ldwork);
+int plasma_core_zttmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m1, int n1, int m2, int n2, int k, int ib,
+    plasma_complex64_t *A1,   int lda1,
+    plasma_complex64_t *A2,   int lda2,
+    const plasma_complex64_t *V,    int ldv,
+    const plasma_complex64_t *T,    int ldt,
+    plasma_complex64_t *work, int ldwork);
 
-int plasma_core_zttqrt(int m, int n, int ib,
-                plasma_complex64_t *A1, int lda1,
-                plasma_complex64_t *A2, int lda2,
-                plasma_complex64_t *T,  int ldt,
-                plasma_complex64_t *tau,
-                plasma_complex64_t *work);
+int plasma_core_zttqrt(
+    int m, int n, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    plasma_complex64_t *T,  int ldt,
+    plasma_complex64_t *tau,
+    plasma_complex64_t *work);
 
-int plasma_core_zunmlq(plasma_enum_t side, plasma_enum_t trans,
-                int m, int n, int k, int ib,
-                const plasma_complex64_t *A,    int lda,
-                const plasma_complex64_t *T,    int ldt,
-                      plasma_complex64_t *C,    int ldc,
-                      plasma_complex64_t *work, int ldwork);
+int plasma_core_zunmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m, int n, int k, int ib,
+    const plasma_complex64_t *A,    int lda,
+    const plasma_complex64_t *T,    int ldt,
+    plasma_complex64_t *C,    int ldc,
+    plasma_complex64_t *work, int ldwork);
 
-int plasma_core_zunmqr(plasma_enum_t side, plasma_enum_t trans,
-                int m, int n, int k, int ib,
-                const plasma_complex64_t *A,    int lda,
-                const plasma_complex64_t *T,    int ldt,
-                      plasma_complex64_t *C,    int ldc,
-                      plasma_complex64_t *work, int ldwork);
+int plasma_core_zunmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m, int n, int k, int ib,
+    const plasma_complex64_t *A,    int lda,
+    const plasma_complex64_t *T,    int ldt,
+    plasma_complex64_t *C,    int ldc,
+    plasma_complex64_t *work, int ldwork);
 
 /******************************************************************************/
-void plasma_core_omp_dzamax(int colrow, int m, int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *values,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_dzamax(
+    int colrow, int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *values,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 void plasma_core_omp_zgeadd(
     plasma_enum_t transa, int m, int n,
@@ -338,11 +388,12 @@ void plasma_core_omp_zgeadd(
     plasma_complex64_t beta,        plasma_complex64_t *B, int ldb,
     plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zgelqt(int m, int n, int ib,
-                     plasma_complex64_t *A, int lda,
-                     plasma_complex64_t *T, int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zgelqt(
+    int m, int n, int ib,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *T, int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 void plasma_core_omp_zgemm(
     plasma_enum_t transa, plasma_enum_t transb,
@@ -352,28 +403,32 @@ void plasma_core_omp_zgemm(
     plasma_complex64_t beta,        plasma_complex64_t *C, int ldc,
     plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zgeqrt(int m, int n, int ib,
-                     plasma_complex64_t *A, int lda,
-                     plasma_complex64_t *T, int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zgeqrt(
+    int m, int n, int ib,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *T, int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zgessq(int m, int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *scale, double *sumsq,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zgessq(
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *scale, double *sumsq,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zgessq_aux(int n,
-                         const double *scale, const double *sumsq,
-                         double *value,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_core_omp_zgessq_aux(
+    int n,
+    const double *scale, const double *sumsq,
+    double *value,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_core_omp_zhegst(int itype, plasma_enum_t uplo,
-                     int n,
-                     plasma_complex64_t *A, int lda,
-                     plasma_complex64_t *B, int ldb,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zhegst(
+    int itype, plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *B, int ldb,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 void plasma_core_omp_zhemm(
     plasma_enum_t side, plasma_enum_t uplo,
@@ -391,124 +446,143 @@ void plasma_core_omp_zher2k(
     double beta,                    plasma_complex64_t *C, int ldc,
     plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zherk(plasma_enum_t uplo, plasma_enum_t trans,
-                    int n, int k,
-                    double alpha, const plasma_complex64_t *A, int lda,
-                    double beta,        plasma_complex64_t *C, int ldc,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zherk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    int n, int k,
+    double alpha, const plasma_complex64_t *A, int lda,
+    double beta,        plasma_complex64_t *C, int ldc,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zhessq(plasma_enum_t uplo,
-                     int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *scale, double *sumsq,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zhessq(
+    plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *scale, double *sumsq,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zsyssq(plasma_enum_t uplo,
-                     int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *scale, double *sumsq,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zsyssq(
+    plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *scale, double *sumsq,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zsyssq_aux(int m, int n,
-                         const double *scale, const double *sumsq,
-                         double *value,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_core_omp_zsyssq_aux(
+    int m, int n,
+    const double *scale, const double *sumsq,
+    double *value,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_core_omp_zlacpy(plasma_enum_t uplo, plasma_enum_t transa,
-                     int m, int n,
-                     const plasma_complex64_t *A, int lda,
-                           plasma_complex64_t *B, int ldb,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zlacpy(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    plasma_complex64_t *B, int ldb,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zlacpy_lapack2tile_band(plasma_enum_t uplo,
-                                      int it, int jt,
-                                      int m, int n, int nb, int kl, int ku,
-                                      const plasma_complex64_t *A, int lda,
-                                            plasma_complex64_t *B, int ldb);
+void plasma_core_omp_zlacpy_lapack2tile_band(
+    plasma_enum_t uplo,
+    int it, int jt,
+    int m, int n, int nb, int kl, int ku,
+    const plasma_complex64_t *A, int lda,
+    plasma_complex64_t *B, int ldb);
 
-void plasma_core_omp_zlacpy_tile2lapack_band(plasma_enum_t uplo,
-                                      int it, int jt,
-                                      int m, int n, int nb, int kl, int ku,
-                                      const plasma_complex64_t *B, int ldb,
-                                            plasma_complex64_t *A, int lda);
+void plasma_core_omp_zlacpy_tile2lapack_band(
+    plasma_enum_t uplo,
+    int it, int jt,
+    int m, int n, int nb, int kl, int ku,
+    const plasma_complex64_t *B, int ldb,
+    plasma_complex64_t *A, int lda);
 
-void plasma_core_omp_zlange(plasma_enum_t norm,
-                     int m, int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *work, double *result,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zlange(
+    plasma_enum_t norm,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *work, double *result,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zlange_aux(plasma_enum_t norm,
-                         int m, int n,
-                         const plasma_complex64_t *A, int lda,
-                         double *value,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_core_omp_zlange_aux(
+    plasma_enum_t norm,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *value,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_core_omp_zlanhe(plasma_enum_t norm, plasma_enum_t uplo,
-                     int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *work, double *value,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zlanhe(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zlanhe_aux(plasma_enum_t norm, plasma_enum_t uplo,
-                         int n,
-                         const plasma_complex64_t *A, int lda,
-                         double *value,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_core_omp_zlanhe_aux(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *value,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_core_omp_zlansy(plasma_enum_t norm, plasma_enum_t uplo,
-                     int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *work, double *value,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zlansy(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zlansy_aux(plasma_enum_t norm, plasma_enum_t uplo,
-                         int n,
-                         const plasma_complex64_t *A, int lda,
-                         double *value,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_core_omp_zlansy_aux(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    int n,
+    const plasma_complex64_t *A, int lda,
+    double *value,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_core_omp_zlantr(plasma_enum_t norm, plasma_enum_t uplo, plasma_enum_t diag,
-                     int m, int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *work, double *value,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zlantr(
+    plasma_enum_t norm, plasma_enum_t uplo, plasma_enum_t diag,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zlantr_aux(plasma_enum_t norm, plasma_enum_t uplo,
-                         plasma_enum_t diag,
-                         int m, int n,
-                         const plasma_complex64_t *A, int lda,
-                         double *value,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_core_omp_zlantr_aux(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    plasma_enum_t diag,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *value,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_core_omp_zlascl(plasma_enum_t uplo,
-                     double cfrom, double cto,
-                     int m, int n,
-                     plasma_complex64_t *A, int lda,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zlascl(
+    plasma_enum_t uplo,
+    double cfrom, double cto,
+    int m, int n,
+    plasma_complex64_t *A, int lda,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zlaset(plasma_enum_t uplo,
-                     int mb, int nb,
-                     int i, int j,
-                     int m, int n,
-                     plasma_complex64_t alpha, plasma_complex64_t beta,
-                     plasma_complex64_t *A);
+void plasma_core_omp_zlaset(
+    plasma_enum_t uplo,
+    int mb, int nb,
+    int i, int j,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t beta,
+    plasma_complex64_t *A);
 
-void plasma_core_omp_zlauum(plasma_enum_t uplo,
-                     int n,
-                     plasma_complex64_t *A, int lda,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zlauum(
+    plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *A, int lda,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zpotrf(plasma_enum_t uplo,
-                     int n,
-                     plasma_complex64_t *A, int lda,
-                     int iinfo,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zpotrf(
+    plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *A, int lda,
+    int iinfo,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 void plasma_core_omp_zsymm(
     plasma_enum_t side, plasma_enum_t uplo,
@@ -556,97 +630,109 @@ void plasma_core_omp_ztrsm(
                                     plasma_complex64_t *B, int ldb,
     plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_ztrssq(plasma_enum_t uplo, plasma_enum_t diag,
-                     int m, int n,
-                     const plasma_complex64_t *A, int lda,
-                     double *scale, double *sumsq,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_ztrssq(
+    plasma_enum_t uplo, plasma_enum_t diag,
+    int m, int n,
+    const plasma_complex64_t *A, int lda,
+    double *scale, double *sumsq,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_ztrtri(plasma_enum_t uplo, plasma_enum_t diag,
-                     int n,
-                     plasma_complex64_t *A, int lda,
-                     int iinfo,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_ztrtri(
+    plasma_enum_t uplo, plasma_enum_t diag,
+    int n,
+    plasma_complex64_t *A, int lda,
+    int iinfo,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_ztslqt(int m, int n, int ib,
-                     plasma_complex64_t *A1, int lda1,
-                     plasma_complex64_t *A2, int lda2,
-                     plasma_complex64_t *T,  int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_ztslqt(
+    int m, int n, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    plasma_complex64_t *T,  int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_ztsmlq(plasma_enum_t side, plasma_enum_t trans,
-                     int m1, int n1, int m2, int n2, int k, int ib,
-                           plasma_complex64_t *A1, int lda1,
-                           plasma_complex64_t *A2, int lda2,
-                     const plasma_complex64_t *V,  int ldv,
-                     const plasma_complex64_t *T,  int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_ztsmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m1, int n1, int m2, int n2, int k, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    const plasma_complex64_t *V,  int ldv,
+    const plasma_complex64_t *T,  int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_ztsmqr(plasma_enum_t side, plasma_enum_t trans,
-                     int m1, int n1, int m2, int n2, int k, int ib,
-                           plasma_complex64_t *A1, int lda1,
-                           plasma_complex64_t *A2, int lda2,
-                     const plasma_complex64_t *V, int ldv,
-                     const plasma_complex64_t *T, int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_ztsmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m1, int n1, int m2, int n2, int k, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    const plasma_complex64_t *V, int ldv,
+    const plasma_complex64_t *T, int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_ztsqrt(int m, int n, int ib,
-                     plasma_complex64_t *A1, int lda1,
-                     plasma_complex64_t *A2, int lda2,
-                     plasma_complex64_t *T,  int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_ztsqrt(
+    int m, int n, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    plasma_complex64_t *T,  int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zttlqt(int m, int n, int ib,
-                     plasma_complex64_t *A1, int lda1,
-                     plasma_complex64_t *A2, int lda2,
-                     plasma_complex64_t *T,  int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zttlqt(
+    int m, int n, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    plasma_complex64_t *T,  int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zttmlq(plasma_enum_t side, plasma_enum_t trans,
-                     int m1, int n1, int m2, int n2, int k, int ib,
-                           plasma_complex64_t *A1, int lda1,
-                           plasma_complex64_t *A2, int lda2,
-                     const plasma_complex64_t *V,  int ldv,
-                     const plasma_complex64_t *T,  int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zttmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m1, int n1, int m2, int n2, int k, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    const plasma_complex64_t *V,  int ldv,
+    const plasma_complex64_t *T,  int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zttmqr(plasma_enum_t side, plasma_enum_t trans,
-                     int m1, int n1, int m2, int n2, int k, int ib,
-                           plasma_complex64_t *A1, int lda1,
-                           plasma_complex64_t *A2, int lda2,
-                     const plasma_complex64_t *V, int ldv,
-                     const plasma_complex64_t *T, int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zttmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m1, int n1, int m2, int n2, int k, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    const plasma_complex64_t *V, int ldv,
+    const plasma_complex64_t *T, int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zttqrt(int m, int n, int ib,
-                     plasma_complex64_t *A1, int lda1,
-                     plasma_complex64_t *A2, int lda2,
-                     plasma_complex64_t *T,  int ldt,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zttqrt(
+    int m, int n, int ib,
+    plasma_complex64_t *A1, int lda1,
+    plasma_complex64_t *A2, int lda2,
+    plasma_complex64_t *T,  int ldt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zunmlq(plasma_enum_t side, plasma_enum_t trans,
-                     int m, int n, int k, int ib,
-                     const plasma_complex64_t *A, int lda,
-                     const plasma_complex64_t *T, int ldt,
-                           plasma_complex64_t *C, int ldc,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zunmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m, int n, int k, int ib,
+    const plasma_complex64_t *A, int lda,
+    const plasma_complex64_t *T, int ldt,
+    plasma_complex64_t *C, int ldc,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_zunmqr(plasma_enum_t side, plasma_enum_t trans,
-                     int m, int n, int k, int ib,
-                     const plasma_complex64_t *A, int lda,
-                     const plasma_complex64_t *T, int ldt,
-                           plasma_complex64_t *C, int ldc,
-                     plasma_workspace_t work,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zunmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m, int n, int k, int ib,
+    const plasma_complex64_t *A, int lda,
+    const plasma_complex64_t *T, int ldt,
+    plasma_complex64_t *C, int ldc,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 #undef COMPLEX
 

--- a/include/plasma_core_blas_zc.h
+++ b/include/plasma_core_blas_zc.h
@@ -21,24 +21,28 @@ extern "C" {
 #endif
 
 /******************************************************************************/
-int plasma_core_zlag2c(int m, int n,
-                 plasma_complex64_t *A,  int lda,
-                 plasma_complex32_t *As, int ldas);
+int plasma_core_zlag2c(
+    int m, int n,
+    plasma_complex64_t *A,  int lda,
+    plasma_complex32_t *As, int ldas);
 
-void plasma_core_clag2z(int m, int n,
-                 plasma_complex32_t *As, int ldas,
-                 plasma_complex64_t *A,  int lda);
+void plasma_core_clag2z(
+    int m, int n,
+    plasma_complex32_t *As, int ldas,
+    plasma_complex64_t *A,  int lda);
 
 /******************************************************************************/
-void plasma_core_omp_zlag2c(int m, int n,
-                     plasma_complex64_t *A,  int lda,
-                     plasma_complex32_t *As, int ldas,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_zlag2c(
+    int m, int n,
+    plasma_complex64_t *A,  int lda,
+    plasma_complex32_t *As, int ldas,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_core_omp_clag2z(int m, int n,
-                     plasma_complex32_t *As, int ldas,
-                     plasma_complex64_t *A,  int lda,
-                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_core_omp_clag2z(
+    int m, int n,
+    plasma_complex32_t *As, int ldas,
+    plasma_complex64_t *A,  int lda,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/plasma_descriptor.h
+++ b/include/plasma_descriptor.h
@@ -246,33 +246,39 @@ static inline int plasma_tile_mmain_band(plasma_desc_t A, int m, int n)
 }
 
 /******************************************************************************/
-int plasma_desc_general_create(plasma_enum_t dtyp, int mb, int nb,
-                               int lm, int ln, int i, int j, int m, int n,
-                               plasma_desc_t *A);
+int plasma_desc_general_create(
+    plasma_enum_t dtyp, int mb, int nb,
+    int lm, int ln, int i, int j, int m, int n,
+    plasma_desc_t *A);
 
-int plasma_desc_general_band_create(plasma_enum_t dtyp, plasma_enum_t uplo,
-                                    int mb, int nb, int lm, int ln,
-                                    int i, int j, int m, int n, int kl, int ku,
-                                    plasma_desc_t *A);
+int plasma_desc_general_band_create(
+    plasma_enum_t dtyp, plasma_enum_t uplo,
+    int mb, int nb, int lm, int ln,
+    int i, int j, int m, int n, int kl, int ku,
+    plasma_desc_t *A);
 
-int plasma_desc_triangular_create(plasma_enum_t dtyp, plasma_enum_t uplo, int mb, int nb,
-                                  int lm, int ln, int i, int j, int m, int n,
-                                  plasma_desc_t *A);
+int plasma_desc_triangular_create(
+    plasma_enum_t dtyp, plasma_enum_t uplo, int mb, int nb,
+    int lm, int ln, int i, int j, int m, int n,
+    plasma_desc_t *A);
 
 int plasma_desc_destroy(plasma_desc_t *A);
 
-int plasma_desc_general_init(plasma_enum_t precision, void *matrix,
-                             int mb, int nb, int lm, int ln, int i, int j,
-                             int m, int n, plasma_desc_t *A);
+int plasma_desc_general_init(
+    plasma_enum_t precision, void *matrix,
+    int mb, int nb, int lm, int ln, int i, int j,
+    int m, int n, plasma_desc_t *A);
 
-int plasma_desc_general_band_init(plasma_enum_t precision, plasma_enum_t uplo,
-                                  void *matrix, int mb, int nb, int lm, int ln,
-                                  int i, int j, int m, int n, int kl, int ku,
-                                  plasma_desc_t *A);
+int plasma_desc_general_band_init(
+    plasma_enum_t precision, plasma_enum_t uplo,
+    void *matrix, int mb, int nb, int lm, int ln,
+    int i, int j, int m, int n, int kl, int ku,
+    plasma_desc_t *A);
 
-int plasma_desc_triangular_init(plasma_enum_t precision, plasma_enum_t uplo, void *matrix,
-                                int mb, int nb, int lm, int ln, int i, int j,
-                                int m, int n, plasma_desc_t *A);
+int plasma_desc_triangular_init(
+    plasma_enum_t precision, plasma_enum_t uplo, void *matrix,
+    int mb, int nb, int lm, int ln, int i, int j,
+    int m, int n, plasma_desc_t *A);
 
 int plasma_desc_check(plasma_desc_t A);
 int plasma_desc_general_check(plasma_desc_t A);
@@ -280,8 +286,9 @@ int plasma_desc_general_band_check(plasma_desc_t A);
 
 plasma_desc_t plasma_desc_view(plasma_desc_t A, int i, int j, int m, int n);
 
-int plasma_descT_create(plasma_desc_t A, int ib, plasma_enum_t householder_mode,
-                        plasma_desc_t *T);
+int plasma_descT_create(
+    plasma_desc_t A, int ib, plasma_enum_t householder_mode,
+    plasma_desc_t *T);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/plasma_internal_z.h
+++ b/include/plasma_internal_z.h
@@ -22,280 +22,336 @@ extern "C" {
 #endif
 
 /******************************************************************************/
-void plasma_pdzamax(plasma_enum_t colrow,
-                    plasma_desc_t A, double *work, double *values,
+void plasma_pdzamax(
+    plasma_enum_t colrow,
+    plasma_desc_t A, double *work, double *values,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzgbtrf(
+    plasma_desc_t A, int *ipiv,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzdesc2ge(
+    plasma_desc_t A,
+    plasma_complex64_t *pA, int lda,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
+
+void plasma_pzdesc2pb(
+    plasma_desc_t A,
+    plasma_complex64_t *pA, int lda,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
+
+void plasma_pzgbbrd_static(
+    plasma_enum_t uplo, int minmn, int nb, int Vblksiz,
+    plasma_complex64_t *A, int lda,
+    plasma_complex64_t *VQ, plasma_complex64_t *TAUQ,
+    plasma_complex64_t *VP, plasma_complex64_t *TAUP,
+    double *D, double *E, int WANTZ,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzdesc2tr(
+    plasma_desc_t A,
+    plasma_complex64_t *pA, int lda,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
+
+void plasma_pzgb2desc(
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
+
+void plasma_pzge2desc(
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
+
+void plasma_pzgeadd(
+    plasma_enum_t transa,
+    plasma_complex64_t alpha,  plasma_desc_t A,
+    plasma_complex64_t beta,   plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzgelqf(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzgelqf_tree(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
+
+void plasma_pzgemm(
+    plasma_enum_t transa, plasma_enum_t transb,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzgeqrf(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzgeqrf_tree(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
+
+void plasma_pzgetri_aux(
+    plasma_desc_t A, plasma_desc_t W,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzgetrf(
+    plasma_desc_t A, int *ipiv,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+void plasma_pzge2gb(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_workspace_t work,
                     plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgbtrf(plasma_desc_t A, int *ipiv,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzgecpy_tile2lapack_band(
+    plasma_enum_t uplo, plasma_desc_t A,
+    plasma_complex64_t *pA_band, int lda_band,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzdesc2ge(plasma_desc_t A,
-                      plasma_complex64_t *pA, int lda,
-                      plasma_sequence_t *sequence,
-                      plasma_request_t *request);
+void plasma_pzhecpy_tile2lapack_band(
+    plasma_enum_t uplo, plasma_desc_t A,
+    plasma_complex64_t *AB, int ldab,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzdesc2pb(plasma_desc_t A,
-                      plasma_complex64_t *pA, int lda,
-                      plasma_sequence_t *sequence,
-                      plasma_request_t *request);
+void plasma_pzhemm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgbbrd_static(plasma_enum_t uplo, int minmn, int nb, int Vblksiz,
-                    plasma_complex64_t *A, int lda,
-                    plasma_complex64_t *VQ, plasma_complex64_t *TAUQ,
-                    plasma_complex64_t *VP, plasma_complex64_t *TAUP,
-                    double *D, double *E, int WANTZ,
-                    plasma_workspace_t work,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
-    
-void plasma_pzdesc2tr(plasma_desc_t A,
-                      plasma_complex64_t *pA, int lda,
-                      plasma_sequence_t *sequence,
-                      plasma_request_t *request);
+void plasma_pzher2k(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    double beta,              plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgb2desc(plasma_complex64_t *pA, int lda,
-                      plasma_desc_t A,
-                      plasma_sequence_t *sequence,
-                      plasma_request_t *request);
+void plasma_pzherk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    double alpha, plasma_desc_t A,
+    double beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzge2desc(plasma_complex64_t *pA, int lda,
-                      plasma_desc_t A,
-                      plasma_sequence_t *sequence,
-                      plasma_request_t *request);
+void plasma_pzhetrf_aasen(
+    plasma_enum_t uplo,
+    plasma_desc_t A, int *ipiv,
+    plasma_desc_t T,
+    plasma_desc_t W,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgeadd(plasma_enum_t transa,
-                    plasma_complex64_t alpha,  plasma_desc_t A,
-                    plasma_complex64_t beta,   plasma_desc_t B,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlacpy(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    plasma_desc_t A, plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgelqf(plasma_desc_t A, plasma_desc_t T,
-                    plasma_workspace_t work,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlangb(
+    plasma_enum_t norm,
+    plasma_desc_t A, double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgelqf_tree(plasma_desc_t A, plasma_desc_t T,
-                         plasma_workspace_t work,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_pzlarft_blgtrd(
+    int N, int NB,int Vblksiz,
+    plasma_complex64_t *V,
+    plasma_complex64_t *T,
+    plasma_complex64_t *TAU,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_pzgemm(plasma_enum_t transa, plasma_enum_t transb,
-                   plasma_complex64_t alpha, plasma_desc_t A,
-                                             plasma_desc_t B,
-                   plasma_complex64_t beta,  plasma_desc_t C,
-                   plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlange(
+    plasma_enum_t norm,
+    plasma_desc_t A, double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgeqrf(plasma_desc_t A, plasma_desc_t T,
-                    plasma_workspace_t work,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlanhe(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    plasma_desc_t A, double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgeqrf_tree(plasma_desc_t A, plasma_desc_t T,
-                         plasma_workspace_t work,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_pzlansy(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    plasma_desc_t A, double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgetri_aux(plasma_desc_t A, plasma_desc_t W,
-                        plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlantr(
+    plasma_enum_t norm, plasma_enum_t uplo, plasma_enum_t diag,
+    plasma_desc_t A, double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgetrf(plasma_desc_t A, int *ipiv,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlangb(
+    plasma_enum_t norm,
+    plasma_desc_t A, double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzge2gb(plasma_desc_t A, plasma_desc_t T,
-                    plasma_workspace_t work,
-                    plasma_sequence_t *sequence, plasma_request_t *request);    
+void plasma_pzlascl(
+    plasma_enum_t uplo,
+    double cfrom, double cto,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgecpy_tile2lapack_band(plasma_enum_t uplo, plasma_desc_t A,
-                                     plasma_complex64_t *pA_band, int lda_band,
-                                     plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlaset(
+    plasma_enum_t uplo,
+    plasma_complex64_t alpha, plasma_complex64_t beta,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzhecpy_tile2lapack_band(plasma_enum_t uplo, plasma_desc_t A,
-                               plasma_complex64_t *AB, int ldab,
-                               plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzgeswp(
+    plasma_enum_t colrow,
+    plasma_desc_t A, int *ipiv, int incx,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzhemm(plasma_enum_t side, plasma_enum_t uplo,
-                   plasma_complex64_t alpha, plasma_desc_t A,
-                                             plasma_desc_t B,
-                   plasma_complex64_t beta,  plasma_desc_t C,
-                   plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlauum(
+    plasma_enum_t uplo, plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzher2k(plasma_enum_t uplo, plasma_enum_t trans,
-                    plasma_complex64_t alpha, plasma_desc_t A,
-                                              plasma_desc_t B,
-                    double beta,              plasma_desc_t C,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzpb2desc(
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_pzherk(plasma_enum_t uplo, plasma_enum_t trans,
-                   double alpha, plasma_desc_t A,
-                   double beta,  plasma_desc_t C,
-                   plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzpbtrf(
+    plasma_enum_t uplo, plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzhetrf_aasen(plasma_enum_t uplo,
-                          plasma_desc_t A, int *ipiv,
-                          plasma_desc_t T,
-                          plasma_desc_t W,
-                          plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzpotrf(
+    plasma_enum_t uplo, plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlacpy(plasma_enum_t uplo, plasma_enum_t transa,
-                    plasma_desc_t A, plasma_desc_t B,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzsymm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlangb(plasma_enum_t norm,
-                    plasma_desc_t A, double *work, double *value,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzsyr2k(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlarft_blgtrd(int N, int NB,int Vblksiz,
-    			   plasma_complex64_t *V,
-    			   plasma_complex64_t *T,
-   			   plasma_complex64_t *TAU,
- 			   plasma_sequence_t *sequence,
- 			   plasma_request_t *request);
+void plasma_pzsyrk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    plasma_complex64_t alpha, plasma_desc_t A,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlange(plasma_enum_t norm,
-                    plasma_desc_t A, double *work, double *value,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pztbsm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t trans, plasma_enum_t diag,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    const int *ipiv,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlanhe(plasma_enum_t norm, plasma_enum_t uplo,
-                    plasma_desc_t A, double *work, double *value,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pztr2desc(
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_pzlansy(plasma_enum_t norm, plasma_enum_t uplo,
-                    plasma_desc_t A, double *work, double *value,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pztradd(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    plasma_complex64_t alpha,  plasma_desc_t A,
+    plasma_complex64_t beta,   plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlantr(plasma_enum_t norm, plasma_enum_t uplo, plasma_enum_t diag,
-                    plasma_desc_t A, double *work, double *value,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pztrmm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t trans, plasma_enum_t diag,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlangb(plasma_enum_t norm,
-                    plasma_desc_t A, double *work, double *value,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pztrsm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t trans, plasma_enum_t diag,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlascl(plasma_enum_t uplo,
-                    double cfrom, double cto,
-                    plasma_desc_t A,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pztrtri(
+    plasma_enum_t uplo, plasma_enum_t diag,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzlaset(plasma_enum_t uplo,
-                    plasma_complex64_t alpha, plasma_complex64_t beta,
-                    plasma_desc_t A,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzunglq(
+    plasma_desc_t A, plasma_desc_t T, plasma_desc_t Q,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzgeswp(plasma_enum_t colrow,
-                    plasma_desc_t A, int *ipiv, int incx,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzunglq_tree(
+    plasma_desc_t A, plasma_desc_t T, plasma_desc_t Q,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_pzlauum(plasma_enum_t uplo, plasma_desc_t A,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzungqr(
+    plasma_desc_t A, plasma_desc_t T, plasma_desc_t Q,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzpb2desc(plasma_complex64_t *pA, int lda,
-                      plasma_desc_t A,
-                      plasma_sequence_t *sequence,
-                      plasma_request_t *request);
+void plasma_pzungqr_tree(
+    plasma_desc_t A, plasma_desc_t T, plasma_desc_t Q,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_pzpbtrf(plasma_enum_t uplo, plasma_desc_t A,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzunmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    plasma_desc_t A, plasma_desc_t T, plasma_desc_t B,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzpotrf(plasma_enum_t uplo, plasma_desc_t A,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzunmlq_tree(
+    plasma_enum_t side, plasma_enum_t trans,
+    plasma_desc_t A, plasma_desc_t T, plasma_desc_t B,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_pzsymm(plasma_enum_t side, plasma_enum_t uplo,
-                   plasma_complex64_t alpha, plasma_desc_t A,
-                                             plasma_desc_t B,
-                   plasma_complex64_t beta,  plasma_desc_t C,
-                   plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzunmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    plasma_desc_t A, plasma_desc_t T, plasma_desc_t B,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pzsyr2k(plasma_enum_t uplo, plasma_enum_t trans,
-                    plasma_complex64_t alpha, plasma_desc_t A,
-                                              plasma_desc_t B,
-                    plasma_complex64_t beta,  plasma_desc_t C,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzunmqr_blgtrd(
+    plasma_enum_t side,
+    plasma_enum_t trans,
+    int N, int NB, int NE,
+    int Vblksiz, int WANTZ,
+    plasma_complex64_t *V,
+    plasma_complex64_t *T,
+    plasma_complex64_t *TAU,
+    plasma_complex64_t *E, int LDE,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_pzsyrk(plasma_enum_t uplo, plasma_enum_t trans,
-                   plasma_complex64_t alpha, plasma_desc_t A,
-                   plasma_complex64_t beta,  plasma_desc_t C,
-                   plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pztbsm(plasma_enum_t side, plasma_enum_t uplo,
-                   plasma_enum_t trans, plasma_enum_t diag,
-                   plasma_complex64_t alpha, plasma_desc_t A,
-                                             plasma_desc_t B,
-                   const int *ipiv,
-                   plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pztr2desc(plasma_complex64_t *pA, int lda,
-                      plasma_desc_t A,
-                      plasma_sequence_t *sequence,
-                      plasma_request_t *request);
-
-void plasma_pztradd(plasma_enum_t uplo, plasma_enum_t transa,
-                    plasma_complex64_t alpha,  plasma_desc_t A,
-                    plasma_complex64_t beta,   plasma_desc_t B,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pztrmm(plasma_enum_t side, plasma_enum_t uplo,
-                   plasma_enum_t trans, plasma_enum_t diag,
-                   plasma_complex64_t alpha, plasma_desc_t A,
-                                             plasma_desc_t B,
-                   plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pztrsm(plasma_enum_t side, plasma_enum_t uplo,
-                   plasma_enum_t trans, plasma_enum_t diag,
-                   plasma_complex64_t alpha, plasma_desc_t A,
-                                             plasma_desc_t B,
-                   plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pztrtri(plasma_enum_t uplo, plasma_enum_t diag,
-                    plasma_desc_t A,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pzunglq(plasma_desc_t A, plasma_desc_t T, plasma_desc_t Q,
-                    plasma_workspace_t work,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pzunglq_tree(plasma_desc_t A, plasma_desc_t T, plasma_desc_t Q,
-                         plasma_workspace_t work,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
-
-void plasma_pzungqr(plasma_desc_t A, plasma_desc_t T, plasma_desc_t Q,
-                    plasma_workspace_t work,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pzungqr_tree(plasma_desc_t A, plasma_desc_t T, plasma_desc_t Q,
-                         plasma_workspace_t work,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
-
-void plasma_pzunmlq(plasma_enum_t side, plasma_enum_t trans,
-                    plasma_desc_t A, plasma_desc_t T, plasma_desc_t B,
-                    plasma_workspace_t work,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pzunmlq_tree(plasma_enum_t side, plasma_enum_t trans,
-                         plasma_desc_t A, plasma_desc_t T, plasma_desc_t B,
-                         plasma_workspace_t work,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
-
-void plasma_pzunmqr(plasma_enum_t side, plasma_enum_t trans,
-                    plasma_desc_t A, plasma_desc_t T, plasma_desc_t B,
-                    plasma_workspace_t work,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
-
-void plasma_pzunmqr_blgtrd(plasma_enum_t side,
-			   plasma_enum_t trans,
-			   int N, int NB, int NE, 
-			   int Vblksiz, int WANTZ,
-			   plasma_complex64_t *V,
- 			   plasma_complex64_t *T,
-  			   plasma_complex64_t *TAU,
-		           plasma_complex64_t *E, int LDE,
-			   plasma_workspace_t work,
-   			   plasma_sequence_t *sequence,
-   			   plasma_request_t *request);
-
-void plasma_pzunmqr_tree(plasma_enum_t side, plasma_enum_t trans,
-                         plasma_desc_t A, plasma_desc_t T, plasma_desc_t B,
-                         plasma_workspace_t work,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_pzunmqr_tree(
+    plasma_enum_t side, plasma_enum_t trans,
+    plasma_desc_t A, plasma_desc_t T, plasma_desc_t B,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/plasma_internal_zc.h
+++ b/include/plasma_internal_zc.h
@@ -22,11 +22,13 @@ extern "C" {
 #endif
 
 /******************************************************************************/
-void plasma_pzlag2c(plasma_desc_t A, plasma_desc_t As,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pzlag2c(
+    plasma_desc_t A, plasma_desc_t As,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_pclag2z(plasma_desc_t As, plasma_desc_t A,
-                    plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_pclag2z(
+    plasma_desc_t As, plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/plasma_tree.h
+++ b/include/plasma_tree.h
@@ -30,11 +30,12 @@ enum {
  *  QR and LQ factorization.
  * @see plasma_omp_zgeqrf
  **/
-static inline int plasma_tree_insert_operation(int *operations,
-                                               int loperations,
-                                               int ind_op,
-                                               plasma_enum_t kernel,
-                                               int col, int row, int rowpiv)
+static inline int plasma_tree_insert_operation(
+    int *operations,
+    int loperations,
+    int ind_op,
+    plasma_enum_t kernel,
+    int col, int row, int rowpiv)
 {
     assert(ind_op < loperations);
 
@@ -53,10 +54,11 @@ static inline int plasma_tree_insert_operation(int *operations,
  *  QR and LQ factorization.
  * @see plasma_omp_zgeqrf
  **/
-static inline void plasma_tree_get_operation(int *operations,
-                                             int ind_op,
-                                             plasma_enum_t *kernel,
-                                             int *col, int *row, int *rowpiv)
+static inline void plasma_tree_get_operation(
+    int *operations,
+    int ind_op,
+    plasma_enum_t *kernel,
+    int *col, int *row, int *rowpiv)
 {
     *kernel = operations[ind_op*4];
     *col    = operations[ind_op*4+1];
@@ -64,9 +66,10 @@ static inline void plasma_tree_get_operation(int *operations,
     *rowpiv = operations[ind_op*4+3];
 }
 
-void plasma_tree_operations(int mt, int nt,
-                            int **operations, int *num_operations,
-                            plasma_sequence_t *sequence,
-                            plasma_request_t *request);
+void plasma_tree_operations(
+    int mt, int nt,
+    int **operations, int *num_operations,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
 #endif // PLASMA_TREE_H

--- a/include/plasma_tuning.h
+++ b/include/plasma_tuning.h
@@ -18,64 +18,120 @@ extern "C" {
 
 /******************************************************************************/
 void plasma_tuning_init(plasma_context_t *plasma);
+
 void plasma_tuning_finalize(plasma_context_t *plasma);
 
-void plasma_tune_gbmm(plasma_context_t *plasma, plasma_enum_t dtyp,
-                      int m, int n, int k, int kl, int ku);
-void plasma_tune_gbtrf(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n, int bw);
-void plasma_tune_geadd(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_geinv(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_gelqf(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_gemm(plasma_context_t *plasma, plasma_enum_t dtyp,
-                      int m, int n, int k);
-void plasma_tune_geqrf(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_geswp(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_getrf(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_hetrf(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n);
-void plasma_tune_lacpy(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_lag2c(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_lange(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_lansy(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n);
-void plasma_tune_lantr(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_lascl(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_laset(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_lauum(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n);
-void plasma_tune_pbtrf(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n);
-void plasma_tune_poinv(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n);
-void plasma_tune_potrf(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n);
-void plasma_tune_symm(plasma_context_t *plasma, plasma_enum_t dtyp,
-                      int m, int n);
-void plasma_tune_syr2k(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n, int k);
-void plasma_tune_syrk(plasma_context_t *plasma, plasma_enum_t dtyp,
-                      int n, int k);
-void plasma_tune_tradd(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int m, int n);
-void plasma_tune_trmm(plasma_context_t *plasma, plasma_enum_t dtyp,
-                      int m, int n);
-void plasma_tune_trsm(plasma_context_t *plasma, plasma_enum_t dtyp,
-                      int m, int n);
-void plasma_tune_trtri(plasma_context_t *plasma, plasma_enum_t dtyp,
-                       int n);
+void plasma_tune_gbmm(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n, int k, int kl, int ku);
+
+void plasma_tune_gbtrf(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n, int bw);
+
+void plasma_tune_geadd(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_geinv(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_gelqf(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_gemm(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n, int k);
+
+void plasma_tune_geqrf(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_geswp(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_getrf(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_hetrf(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n);
+
+void plasma_tune_lacpy(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_lag2c(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_lange(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_lansy(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n);
+
+void plasma_tune_lantr(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_lascl(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_laset(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_lauum(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n);
+
+void plasma_tune_pbtrf(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n);
+
+void plasma_tune_poinv(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n);
+
+void plasma_tune_potrf(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n);
+
+void plasma_tune_symm(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_syr2k(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n, int k);
+
+void plasma_tune_syrk(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n, int k);
+
+void plasma_tune_tradd(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_trmm(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_trsm(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int m, int n);
+
+void plasma_tune_trtri(
+    plasma_context_t *plasma, plasma_enum_t dtyp,
+    int n);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/plasma_z.h
+++ b/include/plasma_z.h
@@ -26,565 +26,681 @@ extern "C" {
 /***************************************************************************//**
  *  Standard interface.
  **/
-int plasma_dzamax(plasma_enum_t colrow,
-                  int m, int n,
-                  plasma_complex64_t *pA, int lda, double *values);
+int plasma_dzamax(
+    plasma_enum_t colrow,
+    int m, int n,
+    plasma_complex64_t *pA, int lda, double *values);
 
-int plasma_zgbmm(plasma_enum_t transa, plasma_enum_t transb,
-                 int m, int n, int k, int kl, int ku,
-                 plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                                           plasma_complex64_t *pB, int ldb,
-                 plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
+int plasma_zgbmm(
+    plasma_enum_t transa, plasma_enum_t transb,
+    int m, int n, int k, int kl, int ku,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+    plasma_complex64_t *pB, int ldb,
+    plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
 
-int plasma_zgbsv(int n, int kl, int ku, int nrhs,
-                 plasma_complex64_t *pAB, int ldab, int *ipiv,
-                 plasma_complex64_t *pB,  int ldb);
+int plasma_zgbsv(
+    int n, int kl, int ku, int nrhs,
+    plasma_complex64_t *pAB, int ldab, int *ipiv,
+    plasma_complex64_t *pB,  int ldb);
 
-int plasma_zgbtrf(int m, int n, int kl, int ku,
-                  plasma_complex64_t *pA, int lda, int *ipiv);
+int plasma_zgbtrf(
+    int m, int n, int kl, int ku,
+    plasma_complex64_t *pA, int lda, int *ipiv);
 
-int plasma_zgbtrs(plasma_enum_t transa, int n, int kl, int ku, int nrhs,
-                  plasma_complex64_t *pAB, int ldab,
-                  int *ipiv,
-                  plasma_complex64_t *pB,  int ldb);
+int plasma_zgbtrs(
+    plasma_enum_t transa, int n, int kl, int ku, int nrhs,
+    plasma_complex64_t *pAB, int ldab,
+    int *ipiv,
+    plasma_complex64_t *pB,  int ldb);
 
-int plasma_zgeadd(plasma_enum_t transa,
-                  int m, int n,
-                  plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                  plasma_complex64_t beta,  plasma_complex64_t *pB, int ldb);
+int plasma_zgeadd(
+    plasma_enum_t transa,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+    plasma_complex64_t beta,  plasma_complex64_t *pB, int ldb);
 
 int plasma_zgeinv(int m, int n, plasma_complex64_t *pA, int lda, int *ipiv);
 
-int plasma_zgelqf(int m, int n,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t *T);
+int plasma_zgelqf(
+    int m, int n,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t *T);
 
-int plasma_zgelqs(int m, int n, int nrhs,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t T,
-                  plasma_complex64_t *pB, int ldb);
+int plasma_zgelqs(
+    int m, int n, int nrhs,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t T,
+    plasma_complex64_t *pB, int ldb);
 
-int plasma_zgels(plasma_enum_t trans,
-                 int m, int n, int nrhs,
-                 plasma_complex64_t *pA, int lda,
-                 plasma_desc_t *T,
-                 plasma_complex64_t *pB, int ldb);
+int plasma_zgels(
+    plasma_enum_t trans,
+    int m, int n, int nrhs,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t *T,
+    plasma_complex64_t *pB, int ldb);
 
-int plasma_zgemm(plasma_enum_t transa, plasma_enum_t transb,
-                 int m, int n, int k,
-                 plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                                           plasma_complex64_t *pB, int ldb,
-                 plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
+int plasma_zgemm(
+    plasma_enum_t transa, plasma_enum_t transb,
+    int m, int n, int k,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+                              plasma_complex64_t *pB, int ldb,
+    plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
 
-int plasma_zgeqrf(int m, int n,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t *T);
+int plasma_zgeqrf(
+    int m, int n,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t *T);
 
-int plasma_zgeqrs(int m, int n, int nrhs,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t T,
-                  plasma_complex64_t *pB, int ldb);
+int plasma_zgeqrs(
+    int m, int n, int nrhs,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t T,
+    plasma_complex64_t *pB, int ldb);
 
-int plasma_zgesv(int n, int nrhs,
-                 plasma_complex64_t *pA, int lda, int *ipiv,
-                 plasma_complex64_t *pB, int ldb);
+int plasma_zgesv(
+    int n, int nrhs,
+    plasma_complex64_t *pA, int lda, int *ipiv,
+    plasma_complex64_t *pB, int ldb);
 
-void plasma_omp_zgesdd(plasma_enum_t jobu, plasma_enum_t jobvt,
-                       plasma_desc_t A, plasma_desc_t T,
-                       double *S,
-                       plasma_complex64_t *pU,  int ldu,
-                       plasma_complex64_t *pVT, int ldvt,
-                       plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
-    
-int plasma_zgesdd(plasma_enum_t jobu, plasma_enum_t jobvt,
-                  int m, int n,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t *T,
-                  double *S,
-                  plasma_complex64_t *pU,  int ldu,
-                  plasma_complex64_t *pVT, int ldvt);
-    
-int plasma_zgetrf(int m, int n,
-                  plasma_complex64_t *pA, int lda, int *ipiv);
+void plasma_omp_zgesdd(
+    plasma_enum_t jobu, plasma_enum_t jobvt,
+    plasma_desc_t A, plasma_desc_t T,
+    double *S,
+    plasma_complex64_t *pU,  int ldu,
+    plasma_complex64_t *pVT, int ldvt,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
+
+int plasma_zgesdd(
+    plasma_enum_t jobu, plasma_enum_t jobvt,
+    int m, int n,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t *T,
+    double *S,
+    plasma_complex64_t *pU,  int ldu,
+    plasma_complex64_t *pVT, int ldvt);
+
+int plasma_zgetrf(
+    int m, int n,
+    plasma_complex64_t *pA, int lda, int *ipiv);
 
 int plasma_zgetri(int n, plasma_complex64_t *pA, int lda, int *ipiv);
 
 int plasma_zgetri_aux(int n, plasma_complex64_t *pA, int lda);
 
-int plasma_zgetrs(plasma_enum_t trans, int n, int nrhs,
-                  plasma_complex64_t *pA, int lda, int *ipiv,
-                  plasma_complex64_t *pB, int ldb);
+int plasma_zgetrs(
+    plasma_enum_t trans, int n, int nrhs,
+    plasma_complex64_t *pA, int lda, int *ipiv,
+    plasma_complex64_t *pB, int ldb);
 
-int plasma_zhemm(plasma_enum_t side, plasma_enum_t uplo,
-                 int m, int n,
-                 plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                                           plasma_complex64_t *pB, int ldb,
-                 plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
+int plasma_zhemm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+                              plasma_complex64_t *pB, int ldb,
+    plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
 
-int plasma_zher2k(plasma_enum_t uplo, plasma_enum_t trans,
-                  int n, int k,
-                  plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                                            plasma_complex64_t *pB, int ldb,
-                  double beta,              plasma_complex64_t *pC, int ldc);
+int plasma_zher2k(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    int n, int k,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+                              plasma_complex64_t *pB, int ldb,
+    double beta,              plasma_complex64_t *pC, int ldc);
 
-int plasma_zherk(plasma_enum_t uplo, plasma_enum_t trans,
-                 int n, int k,
-                 double alpha, plasma_complex64_t *pA, int lda,
-                 double beta,  plasma_complex64_t *pC, int ldc);
+int plasma_zherk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    int n, int k,
+    double alpha, plasma_complex64_t *pA, int lda,
+    double beta,  plasma_complex64_t *pC, int ldc);
 
-int plasma_zhetrf(plasma_enum_t uplo,
-                  int n,
-                  plasma_complex64_t *pA, int lda, int *ipiv,
-                  plasma_complex64_t *pT, int ldt, int *ipiv2);
+int plasma_zhetrf(
+    plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *pA, int lda, int *ipiv,
+    plasma_complex64_t *pT, int ldt, int *ipiv2);
 
-int plasma_zhesv(plasma_enum_t uplo, int n, int nrhs,
-                 plasma_complex64_t *pA, int lda,
-                 int *ipiv,
-                 plasma_complex64_t *pT, int ldt,
-                 int *ipiv2,
-                 plasma_complex64_t *pB,  int ldb);
+int plasma_zhesv(
+    plasma_enum_t uplo, int n, int nrhs,
+    plasma_complex64_t *pA, int lda,
+    int *ipiv,
+    plasma_complex64_t *pT, int ldt,
+    int *ipiv2,
+    plasma_complex64_t *pB,  int ldb);
 
-int plasma_zhetrs(plasma_enum_t uplo, int n, int nrhs,
-                  plasma_complex64_t *pA, int lda,
-                  int *ipiv,
-                  plasma_complex64_t *pT, int ldt,
-                  int *ipiv2,
-                  plasma_complex64_t *pB,  int ldb);
+int plasma_zhetrs(
+    plasma_enum_t uplo, int n, int nrhs,
+    plasma_complex64_t *pA, int lda,
+    int *ipiv,
+    plasma_complex64_t *pT, int ldt,
+    int *ipiv2,
+    plasma_complex64_t *pB,  int ldb);
 
-int plasma_zlacpy(plasma_enum_t uplo, plasma_enum_t transa,
-                  int m, int n,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_complex64_t *pB, int ldb);
+int plasma_zlacpy(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    int m, int n,
+    plasma_complex64_t *pA, int lda,
+    plasma_complex64_t *pB, int ldb);
 
-void plasma_zlaebz2(zlaebz2_Control_t *Control, plasma_complex64_t lowerBound,
-        plasma_complex64_t upperBound, int nLT_low, int nLT_hi, int numEV);
+void plasma_zlaebz2(
+    zlaebz2_Control_t *Control, plasma_complex64_t lowerBound,
+    plasma_complex64_t upperBound, int nLT_low, int nLT_hi, int numEV);
 
-int plasma_zlaneg2(plasma_complex64_t *diag, plasma_complex64_t *offd, 
-                   int n, plasma_complex64_t u);
+int plasma_zlaneg2(plasma_complex64_t *diag, plasma_complex64_t *offd,
+    int n, plasma_complex64_t u);
 
-double plasma_zlangb(plasma_enum_t norm,
-                     int m, int n, int kl, int ku,
-                     plasma_complex64_t *pAB, int ldab);
+double plasma_zlangb(
+    plasma_enum_t norm,
+    int m, int n, int kl, int ku,
+    plasma_complex64_t *pAB, int ldab);
 
-double plasma_zlange(plasma_enum_t norm,
-                     int m, int n,
-                     plasma_complex64_t *pA, int lda);
+double plasma_zlange(
+    plasma_enum_t norm,
+    int m, int n,
+    plasma_complex64_t *pA, int lda);
 
-double plasma_zlanhe(plasma_enum_t norm, plasma_enum_t uplo,
-                     int n,
-                     plasma_complex64_t *pA, int lda);
+double plasma_zlanhe(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *pA, int lda);
 
-double plasma_zlansy(plasma_enum_t norm, plasma_enum_t uplo,
-                     int n,
-                     plasma_complex64_t *pA, int lda);
+double plasma_zlansy(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *pA, int lda);
 
-double plasma_zlantr(plasma_enum_t norm, plasma_enum_t uplo, plasma_enum_t diag,
-                     int m, int n,
-                     plasma_complex64_t *pA, int lda);
+double plasma_zlantr(
+    plasma_enum_t norm, plasma_enum_t uplo, plasma_enum_t diag,
+    int m, int n,
+    plasma_complex64_t *pA, int lda);
 
-double plasma_zlangb(plasma_enum_t norm,
-                     int m, int n, int kl, int ku,
-                     plasma_complex64_t *pAB, int ldab);
+double plasma_zlangb(
+    plasma_enum_t norm,
+    int m, int n, int kl, int ku,
+    plasma_complex64_t *pAB, int ldab);
 
-int plasma_zlascl(plasma_enum_t uplo,
-                  double cfrom, double cto,
-                  int m, int n,
-                  plasma_complex64_t *pA, int lda);
+int plasma_zlascl(
+    plasma_enum_t uplo,
+    double cfrom, double cto,
+    int m, int n,
+    plasma_complex64_t *pA, int lda);
 
-int plasma_zlaset(plasma_enum_t uplo,
-                  int m, int n,
-                  plasma_complex64_t alpha, plasma_complex64_t beta,
-                  plasma_complex64_t *pA, int lda);
+int plasma_zlaset(
+    plasma_enum_t uplo,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t beta,
+    plasma_complex64_t *pA, int lda);
 
-int plasma_zgeswp(plasma_enum_t colrow,
-                  int m, int n,
-                  plasma_complex64_t *pA, int lda,
-                  int *ipiv, int incx);
+int plasma_zgeswp(
+    plasma_enum_t colrow,
+    int m, int n,
+    plasma_complex64_t *pA, int lda,
+    int *ipiv, int incx);
 
-int plasma_zlauum(plasma_enum_t uplo, int n,
-                  plasma_complex64_t *pA, int lda);
+int plasma_zlauum(
+    plasma_enum_t uplo, int n,
+    plasma_complex64_t *pA, int lda);
 
-int plasma_zpbsv(plasma_enum_t uplo,
-                 int n, int kd, int nrhs,
-                 plasma_complex64_t *pAB, int ldab,
-                 plasma_complex64_t *pB,  int ldb);
+int plasma_zpbsv(
+    plasma_enum_t uplo,
+    int n, int kd, int nrhs,
+    plasma_complex64_t *pAB, int ldab,
+    plasma_complex64_t *pB,  int ldb);
 
-int plasma_zpbtrf(plasma_enum_t uplo,
-                  int n, int kd,
-                  plasma_complex64_t *pAB, int ldab);
+int plasma_zpbtrf(
+    plasma_enum_t uplo,
+    int n, int kd,
+    plasma_complex64_t *pAB, int ldab);
 
-int plasma_zpbtrs(plasma_enum_t uplo,
-                  int n, int kd, int nrhs,
-                  plasma_complex64_t *pAB, int ldab,
-                  plasma_complex64_t *pB,  int ldb);
+int plasma_zpbtrs(
+    plasma_enum_t uplo,
+    int n, int kd, int nrhs,
+    plasma_complex64_t *pAB, int ldab,
+    plasma_complex64_t *pB,  int ldb);
 
-int plasma_zpoinv(plasma_enum_t uplo,
-                  int n,
-                  plasma_complex64_t *pA, int lda);
+int plasma_zpoinv(
+    plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *pA, int lda);
 
-int plasma_zposv(plasma_enum_t uplo,
-                 int n, int nrhs,
-                 plasma_complex64_t *pA, int lda,
-                 plasma_complex64_t *pB, int ldb);
+int plasma_zposv(
+    plasma_enum_t uplo,
+    int n, int nrhs,
+    plasma_complex64_t *pA, int lda,
+    plasma_complex64_t *pB, int ldb);
 
-int plasma_zpotrf(plasma_enum_t uplo,
-                  int n,
-                  plasma_complex64_t *pA, int lda);
+int plasma_zpotrf(
+    plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *pA, int lda);
 
-int plasma_zpotri(plasma_enum_t uplo,
-                  int n,
-                  plasma_complex64_t *pA, int lda);
+int plasma_zpotri(
+    plasma_enum_t uplo,
+    int n,
+    plasma_complex64_t *pA, int lda);
 
-int plasma_zpotrs(plasma_enum_t uplo,
-                  int n, int nrhs,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_complex64_t *pB, int ldb);
+int plasma_zpotrs(
+    plasma_enum_t uplo,
+    int n, int nrhs,
+    plasma_complex64_t *pA, int lda,
+    plasma_complex64_t *pB, int ldb);
 
-int plasma_zstevx2(plasma_enum_t jobtype, plasma_enum_t range, int n, int k, 
-                   plasma_complex64_t *diag, plasma_complex64_t *offd,
-                   plasma_complex64_t vl, plasma_complex64_t vu, int il,
-                   int iu, int *pFound, plasma_complex64_t *pVal, int *pMul,
-                   plasma_complex64_t *pVec);
+int plasma_zstevx2(plasma_enum_t jobtype, plasma_enum_t range, int n, int k,
+    plasma_complex64_t *diag, plasma_complex64_t *offd,
+    plasma_complex64_t vl, plasma_complex64_t vu, int il,
+    int iu, int *pFound, plasma_complex64_t *pVal, int *pMul,
+    plasma_complex64_t *pVec);
 
-int plasma_zsymm(plasma_enum_t side, plasma_enum_t uplo,
-                 int m, int n,
-                 plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                                           plasma_complex64_t *pB, int ldb,
-                 plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
+int plasma_zsymm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+                              plasma_complex64_t *pB, int ldb,
+    plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
 
-int plasma_zsyr2k(plasma_enum_t uplo, plasma_enum_t trans,
-                  int n, int k,
-                  plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                                            plasma_complex64_t *pB, int ldb,
-                  plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
+int plasma_zsyr2k(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    int n, int k,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+                              plasma_complex64_t *pB, int ldb,
+    plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
 
-int plasma_zsyrk(plasma_enum_t uplo, plasma_enum_t trans,
-                 int n, int k,
-                 plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                 plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
+int plasma_zsyrk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    int n, int k,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+    plasma_complex64_t beta,  plasma_complex64_t *pC, int ldc);
 
-int plasma_ztradd(plasma_enum_t uplo, plasma_enum_t transa,
-                  int m, int n,
-                  plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                  plasma_complex64_t beta,  plasma_complex64_t *pB, int ldb);
+int plasma_ztradd(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+    plasma_complex64_t beta,  plasma_complex64_t *pB, int ldb);
 
-int plasma_ztrmm(plasma_enum_t side, plasma_enum_t uplo,
-                 plasma_enum_t transa, plasma_enum_t diag,
-                 int m, int n,
-                 plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                                           plasma_complex64_t *pB, int ldb);
+int plasma_ztrmm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t transa, plasma_enum_t diag,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+                              plasma_complex64_t *pB, int ldb);
 
-int plasma_ztrsm(plasma_enum_t side, plasma_enum_t uplo,
-                 plasma_enum_t transa, plasma_enum_t diag,
-                 int m, int n,
-                 plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
-                                           plasma_complex64_t *pB, int ldb);
+int plasma_ztrsm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t transa, plasma_enum_t diag,
+    int m, int n,
+    plasma_complex64_t alpha, plasma_complex64_t *pA, int lda,
+                              plasma_complex64_t *pB, int ldb);
 
-int plasma_ztrtri(plasma_enum_t uplo, plasma_enum_t diag,
-                  int n, plasma_complex64_t *pA, int lda);
+int plasma_ztrtri(
+    plasma_enum_t uplo, plasma_enum_t diag,
+    int n, plasma_complex64_t *pA, int lda);
 
-int plasma_zunglq(int m, int n, int k,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t T,
-                  plasma_complex64_t *pQ, int ldq);
+int plasma_zunglq(
+    int m, int n, int k,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t T,
+    plasma_complex64_t *pQ, int ldq);
 
-int plasma_zungqr(int m, int n, int k,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t T,
-                  plasma_complex64_t *pQ, int ldq);
+int plasma_zungqr(
+    int m, int n, int k,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t T,
+    plasma_complex64_t *pQ, int ldq);
 
-int plasma_zunmlq(plasma_enum_t side, plasma_enum_t trans,
-                  int m, int n, int k,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t T,
-                  plasma_complex64_t *pC, int ldc);
+int plasma_zunmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m, int n, int k,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t T,
+    plasma_complex64_t *pC, int ldc);
 
-int plasma_zunmqr(plasma_enum_t side, plasma_enum_t trans,
-                  int m, int n, int k,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_desc_t T,
-                  plasma_complex64_t *pC, int ldc);
+int plasma_zunmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    int m, int n, int k,
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t T,
+    plasma_complex64_t *pC, int ldc);
 
 /***************************************************************************//**
  *  Tile asynchronous interface.
  **/
-void plasma_omp_dzamax(plasma_enum_t colrow, plasma_desc_t A,
-                       double *work, double *values,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_dzamax(
+    plasma_enum_t colrow, plasma_desc_t A,
+    double *work, double *values,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgbmm(plasma_enum_t transa, plasma_enum_t transb,
-                      plasma_complex64_t alpha, plasma_desc_t A,
-                                                plasma_desc_t B,
-                      plasma_complex64_t beta,  plasma_desc_t C,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgbmm(
+    plasma_enum_t transa, plasma_enum_t transb,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgbsv(plasma_desc_t AB, int *ipiv, plasma_desc_t B,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgbsv(
+    plasma_desc_t AB, int *ipiv, plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgbtrf(plasma_desc_t A, int *ipiv,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgbtrf(
+    plasma_desc_t A, int *ipiv,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgbtrs(plasma_enum_t transa, plasma_desc_t AB, int *ipiv,
-                       plasma_desc_t B,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgbtrs(
+    plasma_enum_t transa, plasma_desc_t AB, int *ipiv,
+    plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zdesc2ge(plasma_desc_t A,
-                         plasma_complex64_t *pA, int lda,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_omp_zdesc2ge(
+    plasma_desc_t A,
+    plasma_complex64_t *pA, int lda,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_zdesc2pb(plasma_desc_t A,
-                         plasma_complex64_t *pA, int lda,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_omp_zdesc2pb(
+    plasma_desc_t A,
+    plasma_complex64_t *pA, int lda,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_zdesc2tr(plasma_desc_t A,
-                         plasma_complex64_t *pA, int lda,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_omp_zdesc2tr(
+    plasma_desc_t A,
+    plasma_complex64_t *pA, int lda,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_zgb2desc(plasma_complex64_t *pA, int lda,
-                         plasma_desc_t A,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_omp_zgb2desc(
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_zgbset(int m, int n, int kl, int ku,
-                   plasma_complex64_t *pA, int lda);
+void plasma_zgbset(
+    int m, int n, int kl, int ku,
+    plasma_complex64_t *pA, int lda);
 
-void plasma_omp_zge2desc(plasma_complex64_t *pA, int lda,
-                         plasma_desc_t A,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_omp_zge2desc(
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_zgeadd(plasma_enum_t transa,
-                       plasma_complex64_t alpha, plasma_desc_t A,
-                       plasma_complex64_t beta,  plasma_desc_t B,
-                       plasma_sequence_t *sequence, plasma_request_t  *request);
+void plasma_omp_zgeadd(
+    plasma_enum_t transa,
+    plasma_complex64_t alpha, plasma_desc_t A,
+    plasma_complex64_t beta,  plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t  *request);
 
-void plasma_omp_zgeinv(plasma_desc_t A, int *ipiv, plasma_desc_t W,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgeinv(
+    plasma_desc_t A, int *ipiv, plasma_desc_t W,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgelqf(plasma_desc_t A, plasma_desc_t T,
-                       plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgelqf(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgelqs(plasma_desc_t A, plasma_desc_t T,
-                       plasma_desc_t B, plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgelqs(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_desc_t B, plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgels(plasma_enum_t trans,
-                      plasma_desc_t A, plasma_desc_t T,
-                      plasma_desc_t B, plasma_workspace_t work,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgels(
+    plasma_enum_t trans,
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_desc_t B, plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgemm(plasma_enum_t transa, plasma_enum_t transb,
-                      plasma_complex64_t alpha, plasma_desc_t A,
-                                                plasma_desc_t B,
-                      plasma_complex64_t beta,  plasma_desc_t C,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgemm(
+    plasma_enum_t transa, plasma_enum_t transb,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgeqrf(plasma_desc_t A, plasma_desc_t T,
-                       plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgeqrf(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgeqrs(plasma_desc_t A, plasma_desc_t T,
-                       plasma_desc_t B, plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgeqrs(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_desc_t B, plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgesv(plasma_desc_t A, int *ipiv,
-                      plasma_desc_t B,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgesv(
+    plasma_desc_t A, int *ipiv,
+    plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgetrf(plasma_desc_t A, int *ipiv,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgetrf(
+    plasma_desc_t A, int *ipiv,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgetri(plasma_desc_t A, int *ipiv, plasma_desc_t W,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgetri(
+    plasma_desc_t A, int *ipiv, plasma_desc_t W,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgetri_aux(plasma_desc_t A, plasma_desc_t W,
-                           plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgetri_aux(
+    plasma_desc_t A, plasma_desc_t W,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgetrs(plasma_enum_t trans, plasma_desc_t A, int *ipiv,
-                       plasma_desc_t B,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgetrs(
+    plasma_enum_t trans, plasma_desc_t A, int *ipiv,
+    plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zhemm(plasma_enum_t side, plasma_enum_t uplo,
-                      plasma_complex64_t alpha, plasma_desc_t A,
-                                                plasma_desc_t B,
-                      plasma_complex64_t beta,  plasma_desc_t C,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zhemm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zher2k(plasma_enum_t uplo, plasma_enum_t trans,
-                       plasma_complex64_t alpha, plasma_desc_t A,
-                                                 plasma_desc_t B,
-                       double beta,              plasma_desc_t C,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zher2k(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    double beta,              plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zherk(plasma_enum_t uplo, plasma_enum_t trans,
-                      double alpha, plasma_desc_t A,
-                      double beta,  plasma_desc_t C,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zherk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    double alpha, plasma_desc_t A,
+    double beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zhetrf(plasma_enum_t uplo,
-                       plasma_desc_t A, int *ipiv,
-                       plasma_desc_t T, int *ipiv2,
-                       plasma_desc_t W,
-                       plasma_sequence_t *sequence,
-                       plasma_request_t *request);
+void plasma_omp_zhetrf(
+    plasma_enum_t uplo,
+    plasma_desc_t A, int *ipiv,
+    plasma_desc_t T, int *ipiv2,
+    plasma_desc_t W,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_zhesv(plasma_enum_t uplo,
-                      plasma_desc_t A, int *ipiv,
-                      plasma_desc_t T, int *ipiv2,
-                      plasma_desc_t B,
-                      plasma_desc_t W,
-                      plasma_sequence_t *sequence,
-                      plasma_request_t *request);
+void plasma_omp_zhesv(
+    plasma_enum_t uplo,
+    plasma_desc_t A, int *ipiv,
+    plasma_desc_t T, int *ipiv2,
+    plasma_desc_t B,
+    plasma_desc_t W,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_zhetrs(plasma_enum_t uplo,
-                       plasma_desc_t A, int *ipiv,
-                       plasma_desc_t T, int *ipiv2,
-                       plasma_desc_t B,
-                       plasma_sequence_t *sequence,
-                       plasma_request_t *request);
+void plasma_omp_zhetrs(
+    plasma_enum_t uplo,
+    plasma_desc_t A, int *ipiv,
+    plasma_desc_t T, int *ipiv2,
+    plasma_desc_t B,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_zlacpy(plasma_enum_t uplo, plasma_enum_t transa,
-                       plasma_desc_t A, plasma_desc_t B,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlacpy(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    plasma_desc_t A, plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlangb(plasma_enum_t norm, plasma_desc_t AB,
-                       double *work, double *value,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlangb(
+    plasma_enum_t norm, plasma_desc_t AB,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlange(plasma_enum_t norm, plasma_desc_t A,
-                       double *work, double *value,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlange(
+    plasma_enum_t norm, plasma_desc_t A,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlanhe(plasma_enum_t norm, plasma_enum_t uplo, plasma_desc_t A,
-                       double *work, double *value,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlanhe(
+    plasma_enum_t norm, plasma_enum_t uplo, plasma_desc_t A,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlansy(plasma_enum_t norm, plasma_enum_t uplo, plasma_desc_t A,
-                       double *work, double *value,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlansy(
+    plasma_enum_t norm, plasma_enum_t uplo, plasma_desc_t A,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlantr(plasma_enum_t norm, plasma_enum_t uplo,
-                       plasma_enum_t diag, plasma_desc_t A,
-                       double *work, double *value,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlantr(
+    plasma_enum_t norm, plasma_enum_t uplo,
+    plasma_enum_t diag, plasma_desc_t A,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlangb(plasma_enum_t norm, plasma_desc_t AB,
-                       double *work, double *value,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlangb(
+    plasma_enum_t norm, plasma_desc_t AB,
+    double *work, double *value,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlascl(plasma_enum_t uplo,
-                       double cfrom, double cto,
-                       plasma_desc_t A,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlascl(
+    plasma_enum_t uplo,
+    double cfrom, double cto,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlaset(plasma_enum_t uplo,
-                       plasma_complex64_t alpha, plasma_complex64_t beta,
-                       plasma_desc_t A,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlaset(
+    plasma_enum_t uplo,
+    plasma_complex64_t alpha, plasma_complex64_t beta,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zgeswp(plasma_enum_t colrow,
-                       plasma_desc_t A,
-                       int *ipiv, int incx,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zgeswp(
+    plasma_enum_t colrow,
+    plasma_desc_t A,
+    int *ipiv, int incx,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zlauum(plasma_enum_t uplo,
-                       plasma_desc_t A,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlauum(
+    plasma_enum_t uplo,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zpb2desc(plasma_complex64_t *pA, int lda,
-                         plasma_desc_t A,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_omp_zpb2desc(
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_zpbsv(plasma_enum_t uplo, plasma_desc_t AB, plasma_desc_t B,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zpbsv(
+    plasma_enum_t uplo, plasma_desc_t AB, plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zpbtrf(plasma_enum_t uplo, plasma_desc_t AB,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zpbtrf(
+    plasma_enum_t uplo, plasma_desc_t AB,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zpbtrs(plasma_enum_t uplo, plasma_desc_t AB, plasma_desc_t B,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zpbtrs(
+    plasma_enum_t uplo, plasma_desc_t AB, plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zpoinv(plasma_enum_t uplo, plasma_desc_t A,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zpoinv(
+    plasma_enum_t uplo, plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zposv(plasma_enum_t uplo, plasma_desc_t A, plasma_desc_t B,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zposv(
+    plasma_enum_t uplo, plasma_desc_t A, plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zpotrf(plasma_enum_t uplo, plasma_desc_t A,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zpotrf(
+    plasma_enum_t uplo, plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zpotri(plasma_enum_t uplo, plasma_desc_t A,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zpotri(
+    plasma_enum_t uplo, plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zpotrs(plasma_enum_t uplo, plasma_desc_t A, plasma_desc_t B,
-                        plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zpotrs(
+    plasma_enum_t uplo, plasma_desc_t A, plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zsymm(plasma_enum_t side, plasma_enum_t uplo,
-                      plasma_complex64_t alpha, plasma_desc_t A,
-                                                plasma_desc_t B,
-                      plasma_complex64_t beta,  plasma_desc_t C,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zsymm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zsyr2k(plasma_enum_t uplo, plasma_enum_t trans,
-                       plasma_complex64_t alpha, plasma_desc_t A,
-                                                 plasma_desc_t B,
-                       plasma_complex64_t beta,  plasma_desc_t C,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zsyr2k(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zsyrk(plasma_enum_t uplo, plasma_enum_t trans,
-                      plasma_complex64_t alpha, plasma_desc_t A,
-                      plasma_complex64_t beta,  plasma_desc_t C,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zsyrk(
+    plasma_enum_t uplo, plasma_enum_t trans,
+    plasma_complex64_t alpha, plasma_desc_t A,
+    plasma_complex64_t beta,  plasma_desc_t C,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_ztr2desc(plasma_complex64_t *pA, int lda,
-                         plasma_desc_t A,
-                         plasma_sequence_t *sequence,
-                         plasma_request_t *request);
+void plasma_omp_ztr2desc(
+    plasma_complex64_t *pA, int lda,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence,
+    plasma_request_t *request);
 
-void plasma_omp_ztradd(plasma_enum_t uplo, plasma_enum_t transa,
-                       plasma_complex64_t alpha, plasma_desc_t A,
-                       plasma_complex64_t beta,  plasma_desc_t B,
-                       plasma_sequence_t *sequence, plasma_request_t  *request);
+void plasma_omp_ztradd(
+    plasma_enum_t uplo, plasma_enum_t transa,
+    plasma_complex64_t alpha, plasma_desc_t A,
+    plasma_complex64_t beta,  plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t  *request);
 
-void plasma_omp_ztrmm(plasma_enum_t side, plasma_enum_t uplo,
-                      plasma_enum_t transa, plasma_enum_t diag,
-                      plasma_complex64_t alpha, plasma_desc_t A,
-                                                plasma_desc_t B,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_ztrmm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t transa, plasma_enum_t diag,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_ztrsm(plasma_enum_t side, plasma_enum_t uplo,
-                      plasma_enum_t transa, plasma_enum_t diag,
-                      plasma_complex64_t alpha, plasma_desc_t A,
-                                                plasma_desc_t B,
-                      plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_ztrsm(
+    plasma_enum_t side, plasma_enum_t uplo,
+    plasma_enum_t transa, plasma_enum_t diag,
+    plasma_complex64_t alpha, plasma_desc_t A,
+                              plasma_desc_t B,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_ztrtri(plasma_enum_t uplo, plasma_enum_t diag,
-                       plasma_desc_t A,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_ztrtri(
+    plasma_enum_t uplo, plasma_enum_t diag,
+    plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zunglq(plasma_desc_t A, plasma_desc_t T,
-                       plasma_desc_t Q, plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zunglq(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_desc_t Q, plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zungqr(plasma_desc_t A, plasma_desc_t T,
-                       plasma_desc_t Q, plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zungqr(
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_desc_t Q, plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zunmlq(plasma_enum_t side, plasma_enum_t trans,
-                       plasma_desc_t A, plasma_desc_t T,
-                       plasma_desc_t C, plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zunmlq(
+    plasma_enum_t side, plasma_enum_t trans,
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_desc_t C, plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_zunmqr(plasma_enum_t side, plasma_enum_t trans,
-                       plasma_desc_t A, plasma_desc_t T,
-                       plasma_desc_t C, plasma_workspace_t work,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zunmqr(
+    plasma_enum_t side, plasma_enum_t trans,
+    plasma_desc_t A, plasma_desc_t T,
+    plasma_desc_t C, plasma_workspace_t work,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/plasma_zc.h
+++ b/include/plasma_zc.h
@@ -24,58 +24,68 @@ extern "C" {
 /***************************************************************************//**
  *  Standard interface
  **/
-int plasma_zcgesv(int n, int nrhs,
-                  plasma_complex64_t *pA, int lda, int *ipiv,
-                  plasma_complex64_t *pB, int ldb,
-                  plasma_complex64_t *pX, int ldx, int *iter);
+int plasma_zcgesv(
+    int n, int nrhs,
+    plasma_complex64_t *pA, int lda, int *ipiv,
+    plasma_complex64_t *pB, int ldb,
+    plasma_complex64_t *pX, int ldx, int *iter);
 
-int plasma_zcposv(plasma_enum_t uplo, int n, int nrhs,
-                  plasma_complex64_t *pA, int lda,
-                  plasma_complex64_t *pB, int ldb,
-                  plasma_complex64_t *pX, int ldx, int *iter);
+int plasma_zcposv(
+    plasma_enum_t uplo, int n, int nrhs,
+    plasma_complex64_t *pA, int lda,
+    plasma_complex64_t *pB, int ldb,
+    plasma_complex64_t *pX, int ldx, int *iter);
 
-int plasma_zcgbsv(int n, int kl, int ku, int nrhs,
-                  plasma_complex64_t *pAB, int ldab, int *ipiv,
-                  plasma_complex64_t *pB, int ldb,
-                  plasma_complex64_t *pX, int ldx, int *iter);
+int plasma_zcgbsv(
+    int n, int kl, int ku, int nrhs,
+    plasma_complex64_t *pAB, int ldab, int *ipiv,
+    plasma_complex64_t *pB, int ldb,
+    plasma_complex64_t *pX, int ldx, int *iter);
 
-int plasma_zlag2c(int m, int n,
-                  plasma_complex64_t *pA,  int lda,
-                  plasma_complex32_t *pAs, int ldas);
+int plasma_zlag2c(
+    int m, int n,
+    plasma_complex64_t *pA,  int lda,
+    plasma_complex32_t *pAs, int ldas);
 
-int plasma_clag2z(int m, int n,
-                  plasma_complex32_t *pAs, int ldas,
-                  plasma_complex64_t *pA,  int lda);
+int plasma_clag2z(
+    int m, int n,
+    plasma_complex32_t *pAs, int ldas,
+    plasma_complex64_t *pA,  int lda);
 
 /***************************************************************************//**
  *  Tile asynchronous interface
  **/
-void plasma_omp_zcgesv(plasma_desc_t A,  int *ipiv,
-                       plasma_desc_t B,  plasma_desc_t X,
-                       plasma_desc_t As, plasma_desc_t Xs, plasma_desc_t R,
-                       double *work, double *Rnorm, double *Xnorm, int *iter,
-                       plasma_sequence_t *sequence,
-                       plasma_request_t  *request);
+void plasma_omp_zcgesv(
+    plasma_desc_t A,  int *ipiv,
+    plasma_desc_t B,  plasma_desc_t X,
+    plasma_desc_t As, plasma_desc_t Xs, plasma_desc_t R,
+    double *work, double *Rnorm, double *Xnorm, int *iter,
+    plasma_sequence_t *sequence,
+    plasma_request_t  *request);
 
-void plasma_omp_zcposv(plasma_enum_t uplo,
-                       plasma_desc_t A,  plasma_desc_t B,  plasma_desc_t X,
-                       plasma_desc_t As, plasma_desc_t Xs, plasma_desc_t R,
-                       double *W,  double *Rnorm, double *Xnorm, int *iter,
-                       plasma_sequence_t *sequence,
-                       plasma_request_t  *request);
+void plasma_omp_zcposv(
+    plasma_enum_t uplo,
+    plasma_desc_t A,  plasma_desc_t B,  plasma_desc_t X,
+    plasma_desc_t As, plasma_desc_t Xs, plasma_desc_t R,
+    double *W,  double *Rnorm, double *Xnorm, int *iter,
+    plasma_sequence_t *sequence,
+    plasma_request_t  *request);
 
-void plasma_omp_zcgbsv(plasma_desc_t A,  int *ipiv,
-                       plasma_desc_t B,  plasma_desc_t X,
-                       plasma_desc_t As, plasma_desc_t Xs, plasma_desc_t R,
-                       double *work, double *Rnorm, double *Xnorm, int *iter,
-                       plasma_sequence_t *sequence,
-                       plasma_request_t  *request);
+void plasma_omp_zcgbsv(
+    plasma_desc_t A,  int *ipiv,
+    plasma_desc_t B,  plasma_desc_t X,
+    plasma_desc_t As, plasma_desc_t Xs, plasma_desc_t R,
+    double *work, double *Rnorm, double *Xnorm, int *iter,
+    plasma_sequence_t *sequence,
+    plasma_request_t  *request);
 
-void plasma_omp_zlag2c(plasma_desc_t A, plasma_desc_t As,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_zlag2c(
+    plasma_desc_t A, plasma_desc_t As,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
-void plasma_omp_clag2z(plasma_desc_t As, plasma_desc_t A,
-                       plasma_sequence_t *sequence, plasma_request_t *request);
+void plasma_omp_clag2z(
+    plasma_desc_t As, plasma_desc_t A,
+    plasma_sequence_t *sequence, plasma_request_t *request);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
The PLASMA style guide* accepts either:
```
    void long_function_name(argument1, argument2,
                            argument3, argument4,
                            argument5);
```
or
```
    void long_function_name(
        argument1, argument2,
        argument3, argument4,
        argument5);
```
The first style is prone to misalignment between the first and second lines (`argument1` and `argument3`) as function names are modified (see file `plasma_core_blas_z.h`), and more easily runs out of space in a 80 char line length. This PR proposes changing to the second style.

\* The PLASMA style guide is seemingly lost to the ether. [SLATE's style guide](https://github.com/icl-utk-edu/slate/wiki/code-style-guide#line-continuation) has the same conventions.