### PR TITLE
cleanup compiler warnings

### DIFF
--- a/compute/pzgeswp.c
+++ b/compute/pzgeswp.c
@@ -37,6 +37,7 @@ void plasma_pzgeswp(plasma_enum_t colrow,
             // Multidependency of the whole panel on its individual tiles.
             for (int m = 1; m < A.mt-1; m++) {
                 plasma_complex64_t *amn = A(m, n);
+                plasma_unused( amn );
                 #pragma omp task depend (in:amn[0]) \
                                  depend (inout:a00[0])
                 {
@@ -63,6 +64,7 @@ void plasma_pzgeswp(plasma_enum_t colrow,
             // Multidependency of individual tiles on the whole panel.
             for (int m = 1; m < A.mt-1; m++) {
                 plasma_complex64_t *amn = A(m, n);
+                plasma_unused( amn );
                 #pragma omp task depend (in:a00[0]) \
                                  depend (inout:amn[0])
                 {
@@ -82,6 +84,7 @@ void plasma_pzgeswp(plasma_enum_t colrow,
             // Multidependency of the whole (row) panel on its individual tiles.
             for (int n = 1; n < A.nt-1; n++) {
                 plasma_complex64_t *amn = A(m, n);
+                plasma_unused( amn );
                 #pragma omp task depend (in:amn[0]) \
                                  depend (inout:a00[0])
                 {
@@ -102,6 +105,7 @@ void plasma_pzgeswp(plasma_enum_t colrow,
             // Multidependency of individual tiles on the whole (row) panel.
             for (int n = 1; n < A.nt-1; n++) {
                 plasma_complex64_t *amn = A(m, n);
+                plasma_unused( amn );
                 #pragma omp task depend (in:a00[0]) \
                                  depend (inout:amn[0])
                 {

--- a/compute/pzgetrf.c
+++ b/compute/pzgetrf.c
@@ -46,6 +46,7 @@ void plasma_pzgetrf(plasma_desc_t A, int *ipiv,
         // doing any useful work.
         for (int m = k+1; m < A.mt-1; m++) {
             plasma_complex64_t *amk = A(m, k);
+            plasma_unused( amk );
             #pragma omp task depend (in:amk[0]) \
                              depend (inout:a00[0]) \
                              priority(1)
@@ -220,6 +221,7 @@ void plasma_pzgetrf(plasma_desc_t A, int *ipiv,
         // Multidependency of individual tiles on the whole panel.
         for (int m = k+2; m < A.mt-1; m++) {
             plasma_complex64_t *amk = A(m, k);
+            plasma_unused( amk );
             #pragma omp task depend (in:a10[0]) \
                              depend (inout:amk[0])
             {

--- a/include/plasma_internal.h
+++ b/include/plasma_internal.h
@@ -39,6 +39,9 @@ static inline int imax(int a, int b)
         return b;
 }
 
+/// Use to silence compiler warning of unused variable.
+#define plasma_unused( var ) ((void) var)
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/test/test_dstevx2.c
+++ b/test/test_dstevx2.c
@@ -87,7 +87,7 @@ static void testMatrix_Kahan(double* diag, double *offd,
 static double testEVec(double *diag, double *offd,
               int n, double *X, double lambda) {
     int i;
-    double mmRes, vmRes, error, sumMM=0., sumVec=0., invLambda = 1.0/lambda;
+    double mmRes, vmRes, sumMM=0., sumVec=0., invLambda = 1.0/lambda;
 
     mmRes = (diag[0]*X[0] + offd[0]*X[1])*invLambda;
     vmRes = X[0];
@@ -176,12 +176,12 @@ void test_dstevx2(param_value_t param[], bool run)
 
     double myDiag=1.e-5;
     testMatrix_Kahan(Diag, Offd, eigenvalues, m, myDiag);
-    double minAbsEV=__DBL_MAX__, maxAbsEV=0., Kond;
+    double minAbsEV=__DBL_MAX__, maxAbsEV=0.;
     for (i=0; i<m; i++) {
         if (fabs(eigenvalues[i]) < minAbsEV) minAbsEV=fabs(eigenvalues[i]);
         if (fabs(eigenvalues[i]) > maxAbsEV) maxAbsEV=fabs(eigenvalues[i]);
     }
-    Kond = maxAbsEV / minAbsEV;
+    //double Kond = maxAbsEV / minAbsEV;
 
     lapack_int nEigVals=0, vectorsFound=0;
     lapack_int il=0, iu=500;
@@ -274,9 +274,11 @@ void test_dstevx2(param_value_t param[], bool run)
          *********************************************************************/
 
         double worstEigenvalue_error = 0, worstEigenvalue_eps;
-        lapack_int worstEigenvalue_index = 0, worstEigenvalue_mpcty = 0, max_mpcty = 0;
+        lapack_int max_mpcty = 0;
+        //lapack_int worstEigenvalue_index = 0;
+        //lapack_int worstEigenvalue_mpcty = 0;
+        //lapack_int worstEigenvector_index = 0;
         double worstEigenvector_error = 0;
-        lapack_int worstEigenvector_index = 0;
         i=0;
         lapack_int evIdx=m-nEigVals;
         while (evIdx < m) {
@@ -286,10 +288,10 @@ void test_dstevx2(param_value_t param[], bool run)
                 double ev_eps = nexttoward(fabs(eigenvalues[evIdx]), __DBL_MAX__) - fabs(eigenvalues[evIdx]);
                 double error = fabs(pVal[i]-eigenvalues[evIdx]) / ev_eps;
                 if (error > worstEigenvalue_error) {
-                    worstEigenvalue_index = i;
+                    //worstEigenvalue_index = i;
                     worstEigenvalue_error = error;
                     worstEigenvalue_eps = ev_eps;
-                    worstEigenvalue_mpcty = pMul[i];
+                    //worstEigenvalue_mpcty = pMul[i];
                 }
 
                 evIdx++; /* advance known eigenvalue index for a multiplicity. */
@@ -326,7 +328,7 @@ void test_dstevx2(param_value_t param[], bool run)
 
             if (vErr > worstEigenvector_error) {
                 worstEigenvector_error = vErr;
-                worstEigenvector_index = i;
+                //worstEigenvector_index = i;
             }
         }
 


### PR DESCRIPTION
These warnings occurred with:
```
pangolin repos/plasma> gcc --version
gcc (Homebrew GCC 14.2.0_1) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
```
In several cases, `amn` is a variable used by OpenMP pragma dependencies, but not by any C code, so the compiler sees them as unused.