### PR TITLE
tools: handle INT_MAX and INT_MIN in fortran_gen.py

### DIFF
--- a/tools/fortran_gen.py
+++ b/tools/fortran_gen.py
@@ -68,6 +68,12 @@ return_variables_dict = {
     "lua_State":         ("lua_state"),
 }
 
+# translation table for macros defining constants
+MacroConsts = {
+    "INT_MAX": "c_intmax_t",
+    "INT_MIN": "-c_intmax_t",
+}
+
 # name arrays which will be translated to assumed-size arrays, e.g. pA(*)
 arrays_names_2D = ["pA", "pB", "pC", "pAB", "pQ", "pX", "pAs"]
 arrays_names_1D = ["ipiv", "values", "work", "W"]
@@ -112,10 +118,9 @@ def polish_file(whole_file):
     clean_file = re.sub(r";", "\n", clean_file)
     clean_file = re.sub(r"}", "}\n", clean_file)
 
-    # Replace INT_MAX with c_intmax_t
-    clean_file = re.sub("INT_MAX", "c_intmax_t", clean_file)
-    # Replace -INT_MIN with -c_intmax_t
-    clean_file = re.sub("INT_MIN", "-c_intmax_t", clean_file)
+    # Replace macro constants with their closest equivalents
+    for name, repl in MacroConsts.items():
+        clean_file = re.sub(name, repl, clean_file)
 
     return clean_file
 

--- a/tools/fortran_gen.py
+++ b/tools/fortran_gen.py
@@ -112,6 +112,11 @@ def polish_file(whole_file):
     clean_file = re.sub(r";", "\n", clean_file)
     clean_file = re.sub(r"}", "}\n", clean_file)
 
+    # Replace INT_MAX with c_intmax_t
+    clean_file = re.sub("INT_MAX", "c_intmax_t", clean_file)
+    # Replace -INT_MIN with -c_intmax_t
+    clean_file = re.sub("INT_MIN", "-c_intmax_t", clean_file)
+
     return clean_file
 
 def preprocess_list(initial_list):


### PR DESCRIPTION
Using fortran_gen.py with the current header files results in errors:
```
$ python3 tools/fortran_gen.py  --prefix include/  include/plasma*h Exported file: include/plasma_mod.f90
$ gfortran -c -o include/plasma_mod.o include/plasma_mod.f90 include/plasma_mod.f90:33:57:

   33 |     integer, parameter :: PlasmaDatatypeUnknown = INT_MIN
      |                                                         1
Error: Symbol ‘int_min’ at (1) has no IMPLICIT type
include/plasma_mod.f90:72:54:

   72 |     integer, parameter :: PlasmaConstUnknown = INT_MIN
      |                                                      1
Error: Symbol ‘int_min’ at (1) has no IMPLICIT type
include/plasma_mod.f90:84:54:

   84 |     integer, parameter :: PlasmaErrorUnknown = INT_MIN
      |                                                      1
Error: Symbol ‘int_min’ at (1) has no IMPLICIT type
include/plasma_mod.f90:88:54:

   88 |     integer, parameter :: PlasmaInoutUnknown = INT_MAX
      |                                                      1
Error: Symbol ‘int_max’ at (1) has no IMPLICIT type; did you mean ‘c_intmax_t’?
include/plasma_mod.f90:92:60:

   92 |     integer, parameter :: PlasmaHouseholderUnknown = INT_MAX
      |                                                            1
Error: Symbol ‘int_max’ at (1) has no IMPLICIT type; did you mean ‘c_intmax_t’?
include/plasma_mod.f90:96:54:

   96 |     integer, parameter :: PlasmaAbledUnknown = INT_MAX
      |                                                      1
Error: Symbol ‘int_max’ at (1) has no IMPLICIT type; did you mean ‘c_intmax_t’?
include/plasma_mod.f90:104:54:

  104 |     integer, parameter :: PlasmaParamUnknown = INT_MAX
      |                                                      1
Error: Symbol ‘int_max’ at (1) has no IMPLICIT type; did you mean ‘c_intmax_t’?
```
With this change `INT_MAX` is converted to `c_intmax_t` and `INT_MIN` to `-c_intmax_t`.